### PR TITLE
Fix test instructions and improve document tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Follow these instructions to get a copy of the project up and running on your lo
 
 1. **Clone the repository:**
    ```sh
-   git clone https://github.com/your-username/portal-image-editor.git
-   cd portal-image-editor
+   git clone https://github.com/your-username/Pixel-Portal.git
+   cd Pixel-Portal
    ```
 
 2. **Create a virtual environment:**
@@ -50,14 +50,14 @@ python -m portal.main
 
 ## Running the Tests
 
-To run the automated tests for this system, you can use the `pytest` command:
+The test suite relies on PySide6 and must run in a headless environment. Set the
+`QT_QPA_PLATFORM` environment variable to `offscreen` and execute each test file
+individually:
 
 ```sh
-pytest
-```
-
-Alternatively, you can use the provided shell script, which will also run the tests:
-
-```sh
-./run_tests.sh
+QT_QPA_PLATFORM=offscreen python -m pytest tests/test_core.py
+QT_QPA_PLATFORM=offscreen python -m pytest tests/test_dialogs.py
+QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py
+QT_QPA_PLATFORM=offscreen python -m pytest tests/test_drawing_tools.py
+QT_QPA_PLATFORM=offscreen python -m pytest tests/test_selection_tools.py
 ```

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -200,6 +200,9 @@ def test_open_document(mock_get_open_file_name, app, qtbot):
 
     assert app.document.width == 32
     assert app.document.height == 32
+    assert len(app.document.layer_manager.layers) == 1
+    top_left = app.document.layer_manager.active_layer.image.pixelColor(0, 0)
+    assert top_left == QColor(0, 0, 0)
     assert document_blocker
     assert undo_blocker
 

--- a/tests/test_drawing_tools.py
+++ b/tests/test_drawing_tools.py
@@ -138,7 +138,7 @@ def line_tool(qtbot):
     mock_canvas.drawing_context.mirror_x = False
     mock_canvas.drawing_context.mirror_y = False
     mock_canvas.selection_shape = None
-    mock_canvas._document_size = (256, 256)
+    mock_canvas._document_size = QSize(256, 256)
     mock_canvas.original_image = QImage(256, 256, QImage.Format_ARGB32)
     mock_canvas.temp_image = None
     mock_canvas.temp_image_replaces_active_layer = False
@@ -334,7 +334,7 @@ def ellipse_tool(qtbot):
     mock_canvas.drawing_context.mirror_x = False
     mock_canvas.drawing_context.mirror_y = False
     mock_canvas.selection_shape = None
-    mock_canvas._document_size = (256, 256)
+    mock_canvas._document_size = QSize(256, 256)
     mock_canvas.original_image = QImage(256, 256, QImage.Format_ARGB32)
     mock_canvas.temp_image = None
     mock_canvas.temp_image_replaces_active_layer = False


### PR DESCRIPTION
## Summary
- Correct project name and headless test instructions in README
- Use `QSize` for mocked canvas sizes in drawing tool tests
- Verify image content when opening a document

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_core.py` *(fails: ImportError: libGL.so.1)*
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_dialogs.py` *(fails: ImportError: libGL.so.1)*
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py` *(fails: ImportError: libGL.so.1)*
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_drawing_tools.py` *(fails: ImportError: libGL.so.1)*
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_selection_tools.py` *(fails: ImportError: libGL.so.1)*
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_segfault.py` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ff172f5c8321b52069f29317fc6e