### PR TITLE
refactor: introduce document and clipboard services

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -14,11 +14,11 @@ class ActionManager:
 
         self.open_action = QAction(QIcon("icons/load.png"), "&Open", self.main_window)
         self.open_action.setShortcut("Ctrl+O")
-        self.open_action.triggered.connect(self.app.open_document)
+        self.open_action.triggered.connect(self.app.document_service.open_document)
 
         self.save_action = QAction(QIcon("icons/save.png"), "&Save", self.main_window)
         self.save_action.setShortcut("Ctrl+S")
-        self.save_action.triggered.connect(self.app.save_document)
+        self.save_action.triggered.connect(self.app.document_service.save_document)
 
         self.save_palette_as_png_action = QAction("Save Palette as PNG...", self.main_window)
         self.save_palette_as_png_action.triggered.connect(self.main_window.save_palette_as_png)
@@ -40,19 +40,19 @@ class ActionManager:
 
         self.cut_action = QAction("Cu&t", self.main_window)
         self.cut_action.setShortcut(QKeySequence.Cut)
-        self.cut_action.triggered.connect(self.app.cut)
+        self.cut_action.triggered.connect(self.app.clipboard_service.cut)
 
         self.copy_action = QAction("&Copy", self.main_window)
         self.copy_action.setShortcut(QKeySequence.Copy)
-        self.copy_action.triggered.connect(self.app.copy)
+        self.copy_action.triggered.connect(self.app.clipboard_service.copy)
 
         self.paste_action = QAction("&Paste", self.main_window)
         self.paste_action.setShortcut(QKeySequence.Paste)
-        self.paste_action.triggered.connect(self.app.paste)
+        self.paste_action.triggered.connect(self.app.clipboard_service.paste)
 
         self.paste_as_new_image_action = QAction("Paste as New Image", self.main_window)
         self.paste_as_new_image_action.setShortcut("Ctrl+Shift+V")
-        self.paste_as_new_image_action.triggered.connect(self.app.paste_as_new_image)
+        self.paste_as_new_image_action.triggered.connect(self.app.clipboard_service.paste_as_new_image)
 
         self.clear_action = QAction(QIcon("icons/clear.png"), "Clear", self.main_window)
         self.clear_action.setShortcut(QKeySequence.Delete)

--- a/portal/core/services/__init__.py
+++ b/portal/core/services/__init__.py
@@ -1,0 +1,4 @@
+from .document_service import DocumentService
+from .clipboard_service import ClipboardService
+
+__all__ = ["DocumentService", "ClipboardService"]

--- a/portal/core/services/clipboard_service.py
+++ b/portal/core/services/clipboard_service.py
@@ -1,0 +1,69 @@
+from PySide6.QtWidgets import QApplication
+from portal.core.command import ClearLayerCommand, PasteCommand, PasteInSelectionCommand
+
+
+class ClipboardService:
+    def __init__(self, document_service, app=None):
+        self.document_service = document_service
+        self.app = app
+
+    def cut(self):
+        app = self.app
+        if not app.document or not app.main_window:
+            return
+
+        self.copy()
+
+        active_layer = app.document.layer_manager.active_layer
+        if not active_layer:
+            return
+
+        selection = app.main_window.canvas.selection_shape
+        command = ClearLayerCommand(active_layer, selection)
+        app.execute_command(command)
+
+    def copy(self):
+        app = self.app
+        if not app.document:
+            return
+
+        image = self.document_service._get_selected_image()
+        if image:
+            QApplication.clipboard().setImage(image)
+
+    def paste(self):
+        app = self.app
+        if not app.document or not app.main_window:
+            return
+
+        clipboard = QApplication.clipboard()
+        image = clipboard.image()
+        if image.isNull():
+            return
+
+        selection = app.main_window.canvas.selection_shape
+        if selection and not selection.isEmpty():
+            command = PasteInSelectionCommand(app.document, image, selection)
+            app.execute_command(command)
+        else:
+            command = PasteCommand(app.document, image)
+            app.execute_command(command)
+
+    def paste_as_new_image(self):
+        app = self.app
+        clipboard = QApplication.clipboard()
+        image = clipboard.image()
+
+        if not image.isNull():
+            app.new_document(image.width(), image.height())
+            command = PasteCommand(app.document, image)
+            app.execute_command(command)
+
+    def paste_as_new_layer(self):
+        app = self.app
+        clipboard = QApplication.clipboard()
+        image = clipboard.image()
+
+        if app.document and not image.isNull():
+            command = PasteCommand(app.document, image)
+            app.execute_command(command)

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -1,0 +1,78 @@
+from PySide6.QtGui import QImage
+from PySide6.QtWidgets import QFileDialog
+import os
+
+from portal.core.document import Document
+
+
+class DocumentService:
+    def __init__(self, app=None):
+        self.app = app
+
+    def open_document(self):
+        app = self.app
+        if not app.check_for_unsaved_changes():
+            return
+
+        file_path, _ = QFileDialog.getOpenFileName(
+            None,
+            "Open Image",
+            app.last_directory,
+            "All Supported Files (*.png *.jpg *.bmp *.tif *.tiff);;Image Files (*.png *.jpg *.bmp);;TIFF Files (*.tif *.tiff)"
+        )
+        if file_path:
+            app.last_directory = os.path.dirname(file_path)
+            app.config.set('General', 'last_directory', app.last_directory)
+
+            if file_path.lower().endswith(('.tif', '.tiff')):
+                app.document = Document.load_tiff(file_path)
+            else:
+                image = QImage(file_path)
+                if not image.isNull():
+                    app.document = Document(image.width(), image.height())
+                    app.document.layer_manager.layers[0].image = image
+
+            app.document.layer_manager.layer_visibility_changed.connect(app.on_layer_visibility_changed)
+            app.document.layer_manager.layer_structure_changed.connect(app.on_layer_structure_changed)
+            app.document.layer_manager.command_generated.connect(app.handle_command)
+            app.undo_manager.clear()
+            app.is_dirty = False
+            app.undo_stack_changed.emit()
+            app.document_changed.emit()
+            if app.main_window:
+                app.main_window.canvas.set_initial_zoom()
+
+    def save_document(self):
+        app = self.app
+        file_path, selected_filter = QFileDialog.getSaveFileName(
+            None,
+            "Save Image",
+            app.last_directory,
+            "PNG (*.png);;JPEG (*.jpg *.jpeg);;Bitmap (*.bmp);;TIFF (*.tif *.tiff)"
+        )
+        if file_path:
+            app.last_directory = os.path.dirname(file_path)
+            app.config.set('General', 'last_directory', app.last_directory)
+
+            if "TIFF" in selected_filter:
+                app.document.save_tiff(file_path)
+            else:
+                image = app.document.render()
+                image.save(file_path)
+
+            app.is_dirty = False
+
+    def _get_selected_image(self):
+        app = self.app
+        if not app.document or not app.main_window:
+            return None
+
+        active_layer = app.document.layer_manager.active_layer
+        if not active_layer:
+            return None
+
+        selection = app.main_window.canvas.selection_shape
+        if selection and not selection.isEmpty():
+            return active_layer.image.copy(selection.boundingRect().toRect())
+        else:
+            return active_layer.image.copy()

--- a/portal/main.py
+++ b/portal/main.py
@@ -2,10 +2,14 @@ import sys
 from PySide6.QtWidgets import QApplication
 from portal.ui.ui import MainWindow
 from portal.core.app import App
+from portal.core.services.document_service import DocumentService
+from portal.core.services.clipboard_service import ClipboardService
 
 if __name__ == "__main__":
     q_app = QApplication(sys.argv)
-    app = App()
+    document_service = DocumentService()
+    clipboard_service = ClipboardService(document_service)
+    app = App(document_service=document_service, clipboard_service=clipboard_service)
     window = MainWindow(app)
     app.main_window = window
     window.show()

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -646,7 +646,7 @@ class TestClipboard:
         app.main_window.canvas.selection_shape = None
 
         # Perform copy
-        app.copy()
+        app.clipboard_service.copy()
 
         # Verify clipboard
         clipboard = QApplication.clipboard()
@@ -672,7 +672,7 @@ class TestClipboard:
         app.main_window.canvas.selection_shape = selection_shape
 
         # Perform copy
-        app.copy()
+        app.clipboard_service.copy()
 
         # Verify clipboard
         clipboard = QApplication.clipboard()
@@ -694,7 +694,7 @@ class TestClipboard:
         app.main_window.canvas.selection_shape = None
 
         # Perform cut
-        app.cut()
+        app.clipboard_service.cut()
 
         # Verify clipboard
         clipboard = QApplication.clipboard()
@@ -725,7 +725,7 @@ class TestClipboard:
         app.main_window.canvas.selection_shape = selection_shape
 
         # Perform cut
-        app.cut()
+        app.clipboard_service.cut()
 
         # Verify clipboard
         clipboard = QApplication.clipboard()
@@ -756,7 +756,7 @@ class TestClipboard:
         app.main_window.canvas.selection_shape = None
 
         # Perform paste
-        app.paste()
+        app.clipboard_service.paste()
 
         # Verify new layer
         assert len(app.document.layer_manager.layers) == initial_layer_count + 1
@@ -776,7 +776,7 @@ class TestClipboard:
         QApplication.clipboard().setImage(image_to_paste)
 
         # Perform paste as new image
-        app.paste_as_new_image()
+        app.clipboard_service.paste_as_new_image()
 
         # Verify new document
         assert app.document.width == 30
@@ -804,7 +804,7 @@ class TestClipboard:
         image_to_paste.fill(QColor("yellow"))
         QApplication.clipboard().setImage(image_to_paste)
 
-        app.paste()
+        app.clipboard_service.paste()
 
         new_layer = app.document.layer_manager.active_layer
         assert new_layer is not active_layer
@@ -834,7 +834,7 @@ class TestClipboard:
         image_to_paste.setPixelColor(0, 0, QColor("red"))
         QApplication.clipboard().setImage(image_to_paste)
 
-        app.paste()
+        app.clipboard_service.paste()
 
         new_layer = app.document.layer_manager.active_layer
         assert new_layer is not active_layer


### PR DESCRIPTION
## Summary
- extract open/save and selection helpers into DocumentService
- move cut/copy/paste logic into ClipboardService and inject services into App
- update main window actions and tests to use new services

## Testing
- `python -m py_compile portal/core/services/document_service.py portal/core/services/clipboard_service.py portal/core/app.py portal/commands/action_manager.py portal/main.py tests/test_core.py tests/test_document_and_layers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c70f388a7c8321b7203191256b0fa7