### PR TITLE
Add category metadata for tools and group toolbar automatically

### DIFF
--- a/portal/commands/tool_bar_builder.py
+++ b/portal/commands/tool_bar_builder.py
@@ -76,60 +76,64 @@ class ToolBarBuilder:
         self.tool_actions = {}
         self.tool_action_group = QActionGroup(self.main_window)
 
-        for tool in tools:
-            if tool.name in ["Line", "Rectangle", "Ellipse", "Select Rectangle", "Select Circle", "Select Lasso", "Select Color"]:
-                continue
-
-            action = QAction(QIcon(tool.icon), tool.name, self.main_window)
+        # Direct access tools (not shape or select)
+        for tool in [t for t in tools if t["category"] not in ("shape", "select")]:
+            action = QAction(QIcon(tool["icon"]), tool["name"], self.main_window)
             action.setCheckable(True)
-            action.triggered.connect(functools.partial(self.app.drawing_context.set_tool, tool.name))
+            action.triggered.connect(
+                functools.partial(self.app.drawing_context.set_tool, tool["name"])
+            )
             button = QToolButton()
             button.setDefaultAction(action)
             self.left_toolbar.addWidget(button)
-            self.tool_actions[tool.name] = action
+            self.tool_actions[tool["name"]] = action
             self.tool_action_group.addAction(action)
-            if tool.name == "Pen":
+            if tool["name"] == "Pen":
                 action.setChecked(True)
 
         # Shape Tools
-        self.main_window.shape_button = QToolButton(self.main_window)
-        self.main_window.shape_button.setIcon(QIcon("icons/toolline.png"))
-        self.main_window.shape_button.setPopupMode(QToolButton.MenuButtonPopup)
-        shape_menu = QMenu(self.main_window.shape_button)
-        self.main_window.shape_button.setMenu(shape_menu)
+        shape_tools = [t for t in tools if t["category"] == "shape"]
+        if shape_tools:
+            self.main_window.shape_button = QToolButton(self.main_window)
+            self.main_window.shape_button.setPopupMode(QToolButton.MenuButtonPopup)
+            shape_menu = QMenu(self.main_window.shape_button)
+            self.main_window.shape_button.setMenu(shape_menu)
 
-        shape_tools = [tool for tool in tools if tool.name in ["Line", "Rectangle", "Ellipse"]]
-        for tool in shape_tools:
-            action = QAction(QIcon(tool.icon), tool.name, self.main_window)
-            action.setCheckable(True)
-            action.triggered.connect(functools.partial(self.app.drawing_context.set_tool, tool.name))
-            shape_menu.addAction(action)
-            self.tool_actions[tool.name] = action
-            self.tool_action_group.addAction(action)
-            if tool.name == "Line":
-                self.main_window.shape_button.setDefaultAction(action)
+            for idx, tool in enumerate(shape_tools):
+                action = QAction(QIcon(tool["icon"]), tool["name"], self.main_window)
+                action.setCheckable(True)
+                action.triggered.connect(
+                    functools.partial(self.app.drawing_context.set_tool, tool["name"])
+                )
+                shape_menu.addAction(action)
+                self.tool_actions[tool["name"]] = action
+                self.tool_action_group.addAction(action)
+                if idx == 0:
+                    self.main_window.shape_button.setDefaultAction(action)
 
-        self.left_toolbar.addWidget(self.main_window.shape_button)
+            self.left_toolbar.addWidget(self.main_window.shape_button)
 
         # Selection Tools
-        self.main_window.selection_button = QToolButton(self.main_window)
-        self.main_window.selection_button.setIcon(QIcon("icons/toolselectrect.png"))
-        self.main_window.selection_button.setPopupMode(QToolButton.MenuButtonPopup)
-        selection_menu = QMenu(self.main_window.selection_button)
-        self.main_window.selection_button.setMenu(selection_menu)
+        selection_tools = [t for t in tools if t["category"] == "select"]
+        if selection_tools:
+            self.main_window.selection_button = QToolButton(self.main_window)
+            self.main_window.selection_button.setPopupMode(QToolButton.MenuButtonPopup)
+            selection_menu = QMenu(self.main_window.selection_button)
+            self.main_window.selection_button.setMenu(selection_menu)
 
-        selection_tools = [tool for tool in tools if tool.name in ["Select Rectangle", "Select Circle", "Select Lasso", "Select Color"]]
-        for tool in selection_tools:
-            action = QAction(QIcon(tool.icon), tool.name, self.main_window)
-            action.setCheckable(True)
-            action.triggered.connect(functools.partial(self.app.drawing_context.set_tool, tool.name))
-            selection_menu.addAction(action)
-            self.tool_actions[tool.name] = action
-            self.tool_action_group.addAction(action)
-            if tool.name == "Select Rectangle":
-                self.main_window.selection_button.setDefaultAction(action)
+            for idx, tool in enumerate(selection_tools):
+                action = QAction(QIcon(tool["icon"]), tool["name"], self.main_window)
+                action.setCheckable(True)
+                action.triggered.connect(
+                    functools.partial(self.app.drawing_context.set_tool, tool["name"])
+                )
+                selection_menu.addAction(action)
+                self.tool_actions[tool["name"]] = action
+                self.tool_action_group.addAction(action)
+                if idx == 0:
+                    self.main_window.selection_button.setDefaultAction(action)
 
-        self.left_toolbar.addWidget(self.main_window.selection_button)
+            self.left_toolbar.addWidget(self.main_window.selection_button)
 
     def update_tool_buttons(self, tool_name):
         if tool_name in self.tool_actions:

--- a/portal/tools/__init__.py
+++ b/portal/tools/__init__.py
@@ -15,6 +15,19 @@ def get_tools():
             module = importlib.import_module(module_name)
             for attribute_name in dir(module):
                 attribute = getattr(module, attribute_name)
-                if isinstance(attribute, type) and issubclass(attribute, BaseTool) and attribute is not BaseTool and attribute.name:
-                    tools.append(attribute)
+                if (
+                    isinstance(attribute, type)
+                    and issubclass(attribute, BaseTool)
+                    and attribute is not BaseTool
+                    and getattr(attribute, "name", None)
+                ):
+                    tools.append(
+                        {
+                            "class": attribute,
+                            "name": attribute.name,
+                            "icon": getattr(attribute, "icon", None),
+                            "shortcut": getattr(attribute, "shortcut", None),
+                            "category": getattr(attribute, "category", None),
+                        }
+                    )
     return tools

--- a/portal/tools/baseselecttool.py
+++ b/portal/tools/baseselecttool.py
@@ -4,6 +4,7 @@ from portal.tools.basetool import BaseTool
 
 
 class BaseSelectTool(BaseTool):
+    category = "select"
     def __init__(self, canvas):
         super().__init__(canvas)
         self.moving_selection = False

--- a/portal/tools/basetool.py
+++ b/portal/tools/basetool.py
@@ -8,6 +8,7 @@ class BaseTool(QObject):
     name = None
     icon = None
     shortcut = None
+    category = None
     command_generated = Signal(object)
 
     def __init__(self, canvas):

--- a/portal/tools/buckettool.py
+++ b/portal/tools/buckettool.py
@@ -9,6 +9,7 @@ class BucketTool(BaseTool):
     name = "Bucket"
     icon = "icons/toolbucket.png"
     shortcut = "f"
+    category = "draw"
 
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
         active_layer = self.canvas.document.layer_manager.active_layer

--- a/portal/tools/ellipsetool.py
+++ b/portal/tools/ellipsetool.py
@@ -9,6 +9,7 @@ class EllipseTool(BaseTool):
     name = "Ellipse"
     icon = "icons/toolellipse.png"
     shortcut = "c"
+    category = "shape"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/erasertool.py
+++ b/portal/tools/erasertool.py
@@ -9,6 +9,7 @@ class EraserTool(BaseTool):
     name = "Eraser"
     icon = "icons/brush.png"
     shortcut = "e"
+    category = "draw"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/linetool.py
+++ b/portal/tools/linetool.py
@@ -9,6 +9,7 @@ class LineTool(BaseTool):
     name = "Line"
     icon = "icons/toolline.png"
     shortcut = "l"
+    category = "shape"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/movetool.py
+++ b/portal/tools/movetool.py
@@ -9,6 +9,7 @@ class MoveTool(BaseTool):
     name = "Move"
     icon = "icons/toolmove.png"
     shortcut = "m"
+    category = "draw"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/pentool.py
+++ b/portal/tools/pentool.py
@@ -8,6 +8,7 @@ class PenTool(BaseTool):
     name = "Pen"
     icon = "icons/toolpen.png"
     shortcut = "b"
+    category = "draw"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/pickertool.py
+++ b/portal/tools/pickertool.py
@@ -6,6 +6,7 @@ class PickerTool(BaseTool):
     name = "Picker"
     icon = "icons/toolpicker.png"
     shortcut = "i"
+    category = "draw"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/rectangletool.py
+++ b/portal/tools/rectangletool.py
@@ -9,6 +9,7 @@ class RectangleTool(BaseTool):
     name = "Rectangle"
     icon = "icons/toolrect.png"
     shortcut = "r"
+    category = "shape"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/rotatetool.py
+++ b/portal/tools/rotatetool.py
@@ -11,6 +11,7 @@ class RotateTool(BaseTool):
     """
     name = "Rotate"
     icon = "icons/toolrotate.png"
+    category = "draw"
     angle_changed = Signal(float)
 
     def __init__(self, canvas):

--- a/portal/tools/selectcircletool.py
+++ b/portal/tools/selectcircletool.py
@@ -8,6 +8,7 @@ class SelectCircleTool(BaseSelectTool):
     name = "Select Circle"
     icon = "icons/toolselectcircle.png"
     shortcut = "a"
+    category = "select"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/selectcolortool.py
+++ b/portal/tools/selectcolortool.py
@@ -7,6 +7,7 @@ class SelectColorTool(BaseTool):
     name = "Select Color"
     icon = "icons/toolselectcolor.png"
     shortcut = "w"
+    category = "select"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/tools/selectlassotool.py
+++ b/portal/tools/selectlassotool.py
@@ -8,6 +8,7 @@ class SelectLassoTool(BaseSelectTool):
     name = "Select Lasso"
     icon = "icons/toolselectlasso.png"
     shortcut = "f"
+    category = "select"
 
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if not self.is_on_selection_border(doc_pos):

--- a/portal/tools/selectrectangletool.py
+++ b/portal/tools/selectrectangletool.py
@@ -8,6 +8,7 @@ class SelectRectangleTool(BaseSelectTool):
     name = "Select Rectangle"
     icon = "icons/toolselectrect.png"
     shortcut = "s"
+    category = "select"
 
     def __init__(self, canvas):
         super().__init__(canvas)

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -62,9 +62,10 @@ class Canvas(QWidget):
         # Properties that were previously in App
         self._document_size = QSize(64, 64)
 
-        self.tools = {tool.name: tool(self) for tool in get_tools()}
+        tool_defs = get_tools()
+        self.tools = {tool_def["name"]: tool_def["class"](self) for tool_def in tool_defs}
         for tool in self.tools.values():
-            if hasattr(tool, 'command_generated'):
+            if hasattr(tool, "command_generated"):
                 tool.command_generated.connect(self.command_generated)
         self.current_tool = self.tools["Pen"]
 

--- a/tests/test_tool_bar_builder.py
+++ b/tests/test_tool_bar_builder.py
@@ -1,0 +1,79 @@
+import types
+
+from PySide6.QtWidgets import QMainWindow
+
+from portal.commands.tool_bar_builder import ToolBarBuilder
+from portal.core.drawing_context import DrawingContext
+from portal.tools.basetool import BaseTool
+
+
+def test_toolbar_groups_tools_by_category(qapp, monkeypatch):
+    main_window = QMainWindow()
+    main_window.action_manager = types.SimpleNamespace()
+    main_window.add_color_to_palette = lambda *args, **kwargs: None
+
+    app = types.SimpleNamespace(drawing_context=DrawingContext())
+    builder = ToolBarBuilder(main_window, app)
+
+    class DummyDrawTool(BaseTool):
+        name = "DummyDraw"
+        icon = "icons/toolpen.png"
+        shortcut = "1"
+        category = "draw"
+
+    class DummyShapeTool(BaseTool):
+        name = "DummyShape"
+        icon = "icons/toolline.png"
+        shortcut = "2"
+        category = "shape"
+
+    class DummySelectTool(BaseTool):
+        name = "DummySelect"
+        icon = "icons/toolselectrect.png"
+        shortcut = "3"
+        category = "select"
+
+    from portal.tools import get_tools as real_get_tools
+
+    def fake_get_tools():
+        tools = real_get_tools()
+        tools.extend(
+            [
+                {
+                    "class": DummyDrawTool,
+                    "name": DummyDrawTool.name,
+                    "icon": DummyDrawTool.icon,
+                    "shortcut": DummyDrawTool.shortcut,
+                    "category": DummyDrawTool.category,
+                },
+                {
+                    "class": DummyShapeTool,
+                    "name": DummyShapeTool.name,
+                    "icon": DummyShapeTool.icon,
+                    "shortcut": DummyShapeTool.shortcut,
+                    "category": DummyShapeTool.category,
+                },
+                {
+                    "class": DummySelectTool,
+                    "name": DummySelectTool.name,
+                    "icon": DummySelectTool.icon,
+                    "shortcut": DummySelectTool.shortcut,
+                    "category": DummySelectTool.category,
+                },
+            ]
+        )
+        return tools
+
+    monkeypatch.setattr("portal.tools.get_tools", fake_get_tools)
+
+    builder._setup_left_toolbar()
+
+    # Direct tools are added as actions on the toolbar
+    assert DummyDrawTool.name in builder.tool_actions
+
+    shape_actions = [a.text() for a in builder.main_window.shape_button.menu().actions()]
+    selection_actions = [a.text() for a in builder.main_window.selection_button.menu().actions()]
+
+    assert DummyShapeTool.name in shape_actions
+    assert DummySelectTool.name in selection_actions
+    assert DummyDrawTool.name not in shape_actions + selection_actions


### PR DESCRIPTION
## Summary
- add `category` attribute to all tools and expose it via `get_tools`
- group toolbar buttons dynamically based on category metadata
- test automatic placement of new tool categories in toolbar

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_tool_bar_builder.py -q`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_drawing_tools.py -q`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_selection_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71453071c83219ab56da8cc81a6a5