### PR TITLE
Refactor into document and settings controllers

### DIFF
--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -47,6 +47,26 @@ class App(QObject):
         return self.document_controller.drawing_context
 
     @property
+    def document_service(self):
+        return self.document_controller.document_service
+
+    @document_service.setter
+    def document_service(self, service):
+        self.document_controller.document_service = service
+        if hasattr(service, "app"):
+            service.app = self.document_controller
+
+    @property
+    def clipboard_service(self):
+        return self.document_controller.clipboard_service
+
+    @clipboard_service.setter
+    def clipboard_service(self, service):
+        self.document_controller.clipboard_service = service
+        if hasattr(service, "app"):
+            service.app = self.document_controller
+
+    @property
     def config(self):
         return self.settings_controller.config
 

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -1,0 +1,181 @@
+from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtGui import QColor, QImage
+from PySide6.QtWidgets import QMessageBox
+
+from portal.core.document import Document
+from portal.core.undo import UndoManager
+from portal.core.drawing_context import DrawingContext
+from portal.core.command import (
+    FlipCommand,
+    ResizeCommand,
+    CropCommand,
+    AddLayerCommand,
+)
+from portal.commands.layer_commands import RemoveBackgroundCommand
+from portal.core.color_utils import find_closest_color
+from portal.core.services.document_service import DocumentService
+from portal.core.services.clipboard_service import ClipboardService
+from portal.core.settings_controller import SettingsController
+
+
+class DocumentController(QObject):
+    """Handles document manipulation and undo stack management."""
+
+    undo_stack_changed = Signal()
+    document_changed = Signal()
+
+    def __init__(self, settings: SettingsController, document_service: DocumentService | None = None, clipboard_service: ClipboardService | None = None):
+        super().__init__()
+        self.settings = settings
+        self.document = Document(64, 64)
+        self.document.layer_manager.layer_visibility_changed.connect(self.on_layer_visibility_changed)
+        self.document.layer_manager.layer_structure_changed.connect(self.on_layer_structure_changed)
+        self.document.layer_manager.command_generated.connect(self.handle_command)
+
+        self.drawing_context = DrawingContext()
+        self.undo_manager = UndoManager()
+
+        self.document_service = document_service or DocumentService()
+        self.clipboard_service = clipboard_service or ClipboardService(self.document_service)
+        self.document_service.app = self
+        self.clipboard_service.app = self
+
+        self.is_recording = False
+        self.recorded_commands = []
+        self.is_dirty = False
+
+        self.main_window = None
+
+    # expose settings-backed properties
+    @property
+    def config(self):
+        return self.settings.config
+
+    @property
+    def last_directory(self):
+        return self.settings.last_directory
+
+    @last_directory.setter
+    def last_directory(self, value):
+        self.settings.last_directory = value
+
+    def execute_command(self, command):
+        command.execute()
+        if self.is_recording:
+            self.recorded_commands.append(command)
+        else:
+            self.undo_manager.add_command(command)
+            self.undo_stack_changed.emit()
+        self.is_dirty = True
+        self.document_changed.emit()
+
+    @Slot(int, int)
+    def new_document(self, width, height):
+        if not self.check_for_unsaved_changes():
+            return
+        self.document = Document(width, height)
+        self.document.layer_manager.layer_visibility_changed.connect(self.on_layer_visibility_changed)
+        self.document.layer_manager.layer_structure_changed.connect(self.on_layer_structure_changed)
+        self.document.layer_manager.command_generated.connect(self.handle_command)
+        self.undo_manager.clear()
+        self.is_dirty = False
+        self.undo_stack_changed.emit()
+        self.document_changed.emit()
+        if self.main_window:
+            self.main_window.canvas.set_initial_zoom()
+
+    def on_layer_visibility_changed(self, index):
+        self.document_changed.emit()
+
+    def on_layer_structure_changed(self):
+        self.document_changed.emit()
+
+    @Slot(int, int, object)
+    def resize_document(self, width, height, interpolation):
+        if self.document:
+            command = ResizeCommand(self.document, width, height, interpolation)
+            self.execute_command(command)
+            if self.main_window:
+                self.main_window.canvas.set_initial_zoom()
+
+    def perform_crop(self, selection_rect):
+        command = CropCommand(self.document, selection_rect)
+        self.execute_command(command)
+
+    @Slot()
+    def undo(self):
+        self.undo_manager.undo()
+        self.undo_stack_changed.emit()
+        self.document_changed.emit()
+
+    @Slot()
+    def redo(self):
+        self.undo_manager.redo()
+        self.undo_stack_changed.emit()
+        self.document_changed.emit()
+
+    @Slot(bool, bool, bool)
+    def flip(self, horizontal, vertical, all_layers):
+        if self.document:
+            command = FlipCommand(self.document, horizontal, vertical, all_layers)
+            self.execute_command(command)
+
+    def add_new_layer_with_image(self, image):
+        command = AddLayerCommand(self.document, image, "AI Generated Layer")
+        self.execute_command(command)
+
+    @Slot(object)
+    def handle_command(self, command):
+        if isinstance(command, tuple):
+            return
+        if command:
+            self.execute_command(command)
+
+    def conform_to_palette(self, palette_hex):
+        if not self.document or not palette_hex:
+            return
+        palette_rgb = [QColor(color).getRgb() for color in palette_hex]
+        source_image = self.document.render()
+        new_image = QImage(source_image.size(), QImage.Format_ARGB32)
+        for y in range(source_image.height()):
+            for x in range(source_image.width()):
+                pixel_color = source_image.pixelColor(x, y).getRgb()
+                closest_color_rgb = find_closest_color(pixel_color, palette_rgb)
+                new_image.setPixelColor(x, y, QColor.fromRgb(*closest_color_rgb))
+        self.add_new_layer_with_image(new_image)
+
+    def remove_background_from_layer(self):
+        layer = self.document.layer_manager.active_layer
+        if not layer:
+            return
+        command = RemoveBackgroundCommand(layer)
+        self.execute_command(command)
+
+    def check_for_unsaved_changes(self):
+        if not self.is_dirty:
+            return True
+        message_box = QMessageBox()
+        message_box.setText("The document has been modified.")
+        message_box.setInformativeText("Do you want to save your changes?")
+        message_box.setStandardButtons(QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel)
+        message_box.setDefaultButton(QMessageBox.Save)
+        ret = message_box.exec()
+        if ret == QMessageBox.Save:
+            self.document_service.save_document()
+            return not self.is_dirty
+        elif ret == QMessageBox.Discard:
+            return True
+        elif ret == QMessageBox.Cancel:
+            return False
+        return False
+
+    @Slot(bool)
+    def set_mirror_x(self, enabled):
+        self.drawing_context.set_mirror_x(enabled)
+
+    @Slot(bool)
+    def set_mirror_y(self, enabled):
+        self.drawing_context.set_mirror_y(enabled)
+
+    def get_current_image(self):
+        return self.document.get_current_image_for_ai()

--- a/portal/core/settings_controller.py
+++ b/portal/core/settings_controller.py
@@ -1,0 +1,34 @@
+from PySide6.QtCore import QObject
+from PySide6.QtWidgets import QMessageBox
+import configparser
+import os
+
+
+class SettingsController(QObject):
+    """Manages application settings persistence."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = configparser.ConfigParser()
+        self.config.read('settings.ini')
+        if not self.config.has_section('General'):
+            self.config.add_section('General')
+        self.last_directory = self.config.get('General', 'last_directory', fallback=os.path.expanduser("~"))
+
+    def save_settings(self, ai_settings=None):
+        """Persist settings to disk."""
+        try:
+            if ai_settings:
+                if not self.config.has_section('AI'):
+                    self.config.add_section('AI')
+                self.config.set('AI', 'last_prompt', ai_settings.get('prompt', ''))
+
+            with open('settings.ini', 'w') as configfile:
+                self.config.write(configfile)
+        except Exception as e:
+            error_box = QMessageBox()
+            error_box.setIcon(QMessageBox.Critical)
+            error_box.setText("Error saving settings")
+            error_box.setInformativeText(f"Could not write to settings.ini.\n\nReason: {e}")
+            error_box.setStandardButtons(QMessageBox.Ok)
+            error_box.exec()


### PR DESCRIPTION
## Summary
- add `DocumentController` to encapsulate document operations and undo/redo logic
- add `SettingsController` to manage configuration persistence
- update `App` to delegate document and settings responsibilities to the new controllers

## Testing
- `python -m py_compile portal/core/settings_controller.py portal/core/document_controller.py portal/core/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7263b19108321a7fa2d4f88094202