### PR TITLE
Add layer opacity slider with undo support

### DIFF
--- a/portal/core/command.py
+++ b/portal/core/command.py
@@ -624,3 +624,16 @@ class MoveLayerCommand(Command):
         if self.layer_manager.active_layer_index == self.to_index:
             self.layer_manager.active_layer_index = self.from_index
         self.layer_manager.layer_structure_changed.emit()
+
+
+class SetLayerOpacityCommand(Command):
+    def __init__(self, layer: Layer, opacity: float):
+        self.layer = layer
+        self.new_opacity = opacity
+        self.old_opacity = layer.opacity
+
+    def execute(self):
+        self.layer.opacity = self.new_opacity
+
+    def undo(self):
+        self.layer.opacity = self.old_opacity

--- a/portal/ui/layer_item_widget.py
+++ b/portal/ui/layer_item_widget.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Signal, Qt, QRect
 from PySide6.QtGui import QPixmap, QPainter, QColor
-from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QLineEdit, QStackedWidget, QSlider
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit, QStackedWidget, QSlider
 
 
 class NameLabel(QLabel):
@@ -97,16 +97,31 @@ class LayerItemWidget(QWidget):
         thumbnail_layout.addWidget(self.thumbnail)
         self.layout.addWidget(thumbnail_container)
 
-        self.label = EditableLabel(self.layer.name)
-        self.label.name_changed.connect(self.on_name_changed)
-        self.layout.addWidget(self.label)
+        # Container for opacity controls and name
+        info_container = QWidget()
+        info_layout = QVBoxLayout(info_container)
+        info_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Opacity row: percentage label + slider
+        opacity_row = QHBoxLayout()
+        opacity_row.setContentsMargins(0, 0, 0, 0)
+        self.opacity_label = QLabel(f"{int(self.layer.opacity * 100)}%")
+        opacity_row.addWidget(self.opacity_label)
 
         self.opacity_slider = QSlider(Qt.Horizontal)
         self.opacity_slider.setRange(0, 100)
         self.opacity_slider.setValue(int(self.layer.opacity * 100))
         self.opacity_slider.setTracking(False)
         self.opacity_slider.valueChanged.connect(self.on_opacity_slider_changed)
-        self.layout.addWidget(self.opacity_slider)
+        opacity_row.addWidget(self.opacity_slider)
+        info_layout.addLayout(opacity_row)
+
+        # Layer name below the opacity controls
+        self.label = EditableLabel(self.layer.name)
+        self.label.name_changed.connect(self.on_name_changed)
+        info_layout.addWidget(self.label)
+
+        self.layout.addWidget(info_container)
 
         self.update_thumbnail()
         self.update_visibility_icon()
@@ -118,6 +133,7 @@ class LayerItemWidget(QWidget):
         self.layer.name = new_name
 
     def on_opacity_slider_changed(self, value):
+        self.opacity_label.setText(f"{value}%")
         self.opacity_changed.emit(value)
 
     def update_thumbnail(self):

--- a/portal/ui/layer_item_widget.py
+++ b/portal/ui/layer_item_widget.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Signal, Qt, QRect
 from PySide6.QtGui import QPixmap, QPainter, QColor
-from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QLineEdit, QStackedWidget
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QLineEdit, QStackedWidget, QSlider
 
 
 class NameLabel(QLabel):
@@ -66,6 +66,7 @@ class ClickableLabel(QLabel):
 
 class LayerItemWidget(QWidget):
     visibility_toggled = Signal()
+    opacity_changed = Signal(int)
 
     def __init__(self, layer):
         super().__init__()
@@ -100,6 +101,13 @@ class LayerItemWidget(QWidget):
         self.label.name_changed.connect(self.on_name_changed)
         self.layout.addWidget(self.label)
 
+        self.opacity_slider = QSlider(Qt.Horizontal)
+        self.opacity_slider.setRange(0, 100)
+        self.opacity_slider.setValue(int(self.layer.opacity * 100))
+        self.opacity_slider.setTracking(False)
+        self.opacity_slider.valueChanged.connect(self.on_opacity_slider_changed)
+        self.layout.addWidget(self.opacity_slider)
+
         self.update_thumbnail()
         self.update_visibility_icon()
         self.layer.on_image_change.connect(self.update_thumbnail)
@@ -108,6 +116,9 @@ class LayerItemWidget(QWidget):
 
     def on_name_changed(self, new_name):
         self.layer.name = new_name
+
+    def on_opacity_slider_changed(self, value):
+        self.opacity_changed.emit(value)
 
     def update_thumbnail(self):
         # The size of the thumbnail label

--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -74,8 +74,11 @@ class LayerManagerWidget(QWidget):
             item_widget.visibility_toggled.connect(
                 lambda widget=item_widget: self.on_visibility_toggled(widget)
             )
+            item_widget.opacity_preview_changed.connect(
+                lambda value, widget=item_widget: self.on_opacity_preview_changed(widget, value)
+            )
             item_widget.opacity_changed.connect(
-                lambda value, widget=item_widget: self.on_opacity_changed(widget, value)
+                lambda old, new, widget=item_widget: self.on_opacity_changed(widget, old, new)
             )
             item.setSizeHint(item_widget.sizeHint())
             self.layer_list.setItemWidget(item, item_widget)
@@ -107,10 +110,17 @@ class LayerManagerWidget(QWidget):
                 self.layer_changed.emit()
                 return
 
-    def on_opacity_changed(self, widget, value):
-        """Handles changing layer opacity via slider."""
+    def on_opacity_preview_changed(self, widget, value):
+        """Preview layer opacity while dragging."""
+        widget.layer.opacity = value / 100.0
+        self.layer_changed.emit()
+
+    def on_opacity_changed(self, widget, old_value, new_value):
+        """Commit an undoable change to layer opacity."""
+        # Restore old value so the command captures it correctly
+        widget.layer.opacity = old_value / 100.0
         from portal.core.command import SetLayerOpacityCommand
-        command = SetLayerOpacityCommand(widget.layer, value / 100.0)
+        command = SetLayerOpacityCommand(widget.layer, new_value / 100.0)
         self.app.execute_command(command)
         self.layer_changed.emit()
 

--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -74,6 +74,9 @@ class LayerManagerWidget(QWidget):
             item_widget.visibility_toggled.connect(
                 lambda widget=item_widget: self.on_visibility_toggled(widget)
             )
+            item_widget.opacity_changed.connect(
+                lambda value, widget=item_widget: self.on_opacity_changed(widget, value)
+            )
             item.setSizeHint(item_widget.sizeHint())
             self.layer_list.setItemWidget(item, item_widget)
 
@@ -103,6 +106,13 @@ class LayerManagerWidget(QWidget):
                 self.app.document.layer_manager.toggle_visibility(actual_index)
                 self.layer_changed.emit()
                 return
+
+    def on_opacity_changed(self, widget, value):
+        """Handles changing layer opacity via slider."""
+        from portal.core.command import SetLayerOpacityCommand
+        command = SetLayerOpacityCommand(widget.layer, value / 100.0)
+        self.app.execute_command(command)
+        self.layer_changed.emit()
 
     def on_layers_moved(self, parent, start, end, destination, row):
         """Handles reordering layers via drag-and-drop."""

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -135,6 +135,26 @@ def test_crop(document):
         assert layer.image.height() == crop_rect.height()
 
 
+def test_set_layer_opacity_command(document):
+    """Test that setting layer opacity is undoable and affects rendering."""
+    top_layer = document.layer_manager.layers[1]
+    bottom_color = document.layer_manager.layers[0].image.pixelColor(50, 50)
+    blended_before = document.render().pixelColor(50, 50)
+
+    from portal.core.command import SetLayerOpacityCommand
+
+    command = SetLayerOpacityCommand(top_layer, 0.0)
+    command.execute()
+    assert top_layer.opacity == 0.0
+    rendered = document.render()
+    assert rendered.pixelColor(50, 50) == bottom_color
+
+    command.undo()
+    assert top_layer.opacity == 1.0
+    rendered_after = document.render()
+    assert rendered_after.pixelColor(50, 50) == blended_before
+
+
 @pytest.fixture
 def layer():
     """Returns a Layer instance."""

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -155,6 +155,33 @@ def test_set_layer_opacity_command(document):
     assert rendered_after.pixelColor(50, 50) == blended_before
 
 
+def test_layer_manager_opacity_preview_and_commit():
+    """Layer opacity previews while dragging and commits with undo support."""
+    from PySide6.QtWidgets import QApplication
+    app_qt = QApplication.instance() or QApplication([])
+    from portal.core.app import App
+    from portal.ui.layer_manager_widget import LayerManagerWidget
+    from unittest.mock import MagicMock
+
+    app = App()
+    app.new_document(10, 10)
+    canvas = MagicMock()
+    lm_widget = LayerManagerWidget(app, canvas)
+
+    item = lm_widget.layer_list.item(0)
+    item_widget = lm_widget.layer_list.itemWidget(item)
+    layer = item_widget.layer
+
+    lm_widget.on_opacity_preview_changed(item_widget, 50)
+    assert layer.opacity == 0.5
+
+    lm_widget.on_opacity_changed(item_widget, 50, 25)
+    assert layer.opacity == 0.25
+
+    app.undo()
+    assert layer.opacity == 0.5
+
+
 @pytest.fixture
 def layer():
     """Returns a Layer instance."""


### PR DESCRIPTION
## Summary
- add slider to layer items to control opacity
- introduce `SetLayerOpacityCommand` for undoable opacity changes
- update layer manager and add tests for opacity adjustments

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7734db53083218569b796753088c8