### PR TITLE
Avoid wrapping drawing preview in tile preview mode

### DIFF
--- a/portal/commands/canvas_input_handler.py
+++ b/portal/commands/canvas_input_handler.py
@@ -33,7 +33,7 @@ class CanvasInputHandler:
 
         doc_pos = self.canvas.get_doc_coords(
             event.position().toPoint(),
-            wrap=self.canvas.tile_preview_enabled,
+            wrap=False,
         )
         if event.button() == Qt.LeftButton:
             self.canvas.current_tool.mousePressEvent(event, doc_pos)
@@ -44,13 +44,15 @@ class CanvasInputHandler:
             self.canvas.last_point = event.position().toPoint()
 
     def mouseMoveEvent(self, event):
-        self.canvas.cursor_doc_pos = self.canvas.get_doc_coords(event.position().toPoint())
+        self.canvas.cursor_doc_pos = self.canvas.get_doc_coords(
+            event.position().toPoint(), wrap=False
+        )
         self.canvas.cursor_pos_changed.emit(self.canvas.cursor_doc_pos)
         self.canvas.update()
 
         doc_pos = self.canvas.get_doc_coords(
             event.position().toPoint(),
-            wrap=self.canvas.tile_preview_enabled,
+            wrap=False,
         )
 
         active_layer = self.canvas.document.layer_manager.active_layer
@@ -86,7 +88,7 @@ class CanvasInputHandler:
 
         doc_pos = self.canvas.get_doc_coords(
             event.position().toPoint(),
-            wrap=self.canvas.tile_preview_enabled,
+            wrap=False,
         )
         if event.button() == Qt.LeftButton:
             self.canvas.current_tool.mouseReleaseEvent(event, doc_pos)

--- a/portal/core/drawing.py
+++ b/portal/core/drawing.py
@@ -111,19 +111,11 @@ class Drawing:
         width = document_size.width()
         height = document_size.height()
 
+        dx = p2.x() - p1.x()
+        dy = p2.y() - p1.y()
         if wrap:
-            end_x = p2.x()
-            end_y = p2.y()
-            if abs(p2.x() - p1.x()) > width / 2:
-                end_x += width if p2.x() < p1.x() else -width
-            if abs(p2.y() - p1.y()) > height / 2:
-                end_y += height if p2.y() < p1.y() else -height
-        else:
-            end_x = p2.x()
-            end_y = p2.y()
-
-        dx = end_x - p1.x()
-        dy = end_y - p1.y()
+            dx = ((dx + width / 2) % width) - width / 2
+            dy = ((dy + height / 2) % height) - height / 2
 
         if erase:
             brush_func = lambda p: self.erase_brush(

--- a/portal/core/renderer.py
+++ b/portal/core/renderer.py
@@ -79,6 +79,15 @@ class CanvasRenderer:
                 )
                 self._draw_background(painter, tile_rect)
                 painter.drawImage(tile_rect, image)
+                overlay = self.canvas.tile_preview_image
+                if overlay is not None:
+                    if self.canvas.is_erasing_preview:
+                        painter.save()
+                        painter.setCompositionMode(QPainter.CompositionMode_DestinationOut)
+                        painter.drawImage(tile_rect, overlay)
+                        painter.restore()
+                    else:
+                        painter.drawImage(tile_rect, overlay)
 
     def _draw_mirror_guides(self, painter, target_rect, document):
         if not self.drawing_context.mirror_x and not self.drawing_context.mirror_y:

--- a/portal/tools/ellipsetool.py
+++ b/portal/tools/ellipsetool.py
@@ -59,7 +59,7 @@ class EllipseTool(BaseTool):
             self.canvas.drawing_context.pen_width,
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
-            wrap=self.canvas.tile_preview_enabled,
+            wrap=False,
         )
         self.canvas.update()
 

--- a/portal/tools/ellipsetool.py
+++ b/portal/tools/ellipsetool.py
@@ -64,7 +64,7 @@ class EllipseTool(BaseTool):
             self.canvas.drawing_context.pen_width,
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
-            wrap=False,
+            wrap=self.canvas.tile_preview_enabled,
         )
         painter.end()
         if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:

--- a/portal/tools/ellipsetool.py
+++ b/portal/tools/ellipsetool.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import QPoint, QRect
-from PySide6.QtGui import QMouseEvent, QPainter, QPen, Qt, QCursor
+from PySide6.QtGui import QMouseEvent, QPainter, QPen, Qt, QCursor, QImage
 
 from portal.tools.basetool import BaseTool
 from portal.core.command import ShapeCommand
@@ -25,6 +25,11 @@ class EllipseTool(BaseTool):
         self.canvas.temp_image_replaces_active_layer = True
         # The command will need the original image state
         self.command_generated.emit(("get_active_layer_image", "ellipse_tool_start"))
+        if self.canvas.tile_preview_enabled:
+            self.canvas.tile_preview_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
+            self.canvas.tile_preview_image.fill(Qt.transparent)
+        else:
+            self.canvas.tile_preview_image = None
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if self.canvas.original_image is None:
@@ -61,6 +66,24 @@ class EllipseTool(BaseTool):
             self.canvas.drawing_context.mirror_y,
             wrap=False,
         )
+        painter.end()
+        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
+            self.canvas.tile_preview_image.fill(Qt.transparent)
+            preview_painter = QPainter(self.canvas.tile_preview_image)
+            if self.canvas.selection_shape:
+                preview_painter.setClipPath(self.canvas.selection_shape)
+            preview_painter.setPen(QPen(self.canvas.drawing_context.pen_color))
+            self.canvas.drawing.draw_ellipse(
+                preview_painter,
+                rect,
+                self.canvas._document_size,
+                self.canvas.drawing_context.brush_type,
+                self.canvas.drawing_context.pen_width,
+                self.canvas.drawing_context.mirror_x,
+                self.canvas.drawing_context.mirror_y,
+                wrap=True,
+            )
+            preview_painter.end()
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
@@ -100,4 +123,5 @@ class EllipseTool(BaseTool):
         self.canvas.temp_image = None
         self.canvas.original_image = None
         self.canvas.temp_image_replaces_active_layer = False
+        self.canvas.tile_preview_image = None
         self.canvas.update()

--- a/portal/tools/erasertool.py
+++ b/portal/tools/erasertool.py
@@ -116,7 +116,7 @@ class EraserTool(BaseTool):
                 self.canvas.drawing_context.pen_width,
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
-                wrap=self.canvas.tile_preview_enabled,
+                wrap=False,
             )
         else:
             for i in range(len(self.points) - 1):
@@ -129,7 +129,7 @@ class EraserTool(BaseTool):
                     self.canvas.drawing_context.pen_width,
                     self.canvas.drawing_context.mirror_x,
                     self.canvas.drawing_context.mirror_y,
-                    wrap=self.canvas.tile_preview_enabled,
+                    wrap=False,
                     erase=False,
                 )
 

--- a/portal/tools/erasertool.py
+++ b/portal/tools/erasertool.py
@@ -127,7 +127,7 @@ class EraserTool(BaseTool):
                 self.canvas.drawing_context.pen_width,
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
-                wrap=False,
+                wrap=self.canvas.tile_preview_enabled,
             )
         else:
             for i in range(len(self.points) - 1):
@@ -140,7 +140,7 @@ class EraserTool(BaseTool):
                     self.canvas.drawing_context.pen_width,
                     self.canvas.drawing_context.mirror_x,
                     self.canvas.drawing_context.mirror_y,
-                    wrap=False,
+                    wrap=self.canvas.tile_preview_enabled,
                     erase=False,
                 )
 

--- a/portal/tools/linetool.py
+++ b/portal/tools/linetool.py
@@ -38,7 +38,7 @@ class LineTool(BaseTool):
             self.canvas.drawing_context.pen_width,
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
-            wrap=self.canvas.tile_preview_enabled,
+            wrap=False,
         )
         painter.end()
         self.canvas.update()

--- a/portal/tools/linetool.py
+++ b/portal/tools/linetool.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import QPoint
-from PySide6.QtGui import QMouseEvent, QPainter, QPen, Qt
+from PySide6.QtGui import QMouseEvent, QPainter, QPen, Qt, QImage
 
 from portal.tools.basetool import BaseTool
 from portal.core.command import DrawCommand
@@ -19,6 +19,11 @@ class LineTool(BaseTool):
         self.start_point = doc_pos
         self.canvas.temp_image_replaces_active_layer = True
         self.command_generated.emit(("get_active_layer_image", "line_tool_start"))
+        if self.canvas.tile_preview_enabled:
+            self.canvas.tile_preview_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
+            self.canvas.tile_preview_image.fill(Qt.transparent)
+        else:
+            self.canvas.tile_preview_image = None
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if self.canvas.original_image is None:
@@ -41,6 +46,24 @@ class LineTool(BaseTool):
             wrap=False,
         )
         painter.end()
+        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
+            self.canvas.tile_preview_image.fill(Qt.transparent)
+            preview_painter = QPainter(self.canvas.tile_preview_image)
+            if self.canvas.selection_shape:
+                preview_painter.setClipPath(self.canvas.selection_shape)
+            preview_painter.setPen(QPen(self.canvas.drawing_context.pen_color))
+            self.canvas.drawing.draw_line_with_brush(
+                preview_painter,
+                self.start_point,
+                doc_pos,
+                self.canvas._document_size,
+                self.canvas.drawing_context.brush_type,
+                self.canvas.drawing_context.pen_width,
+                self.canvas.drawing_context.mirror_x,
+                self.canvas.drawing_context.mirror_y,
+                wrap=True,
+            )
+            preview_painter.end()
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
@@ -69,4 +92,5 @@ class LineTool(BaseTool):
         self.canvas.temp_image = None
         self.canvas.original_image = None
         self.canvas.temp_image_replaces_active_layer = False
+        self.canvas.tile_preview_image = None
         self.canvas.update()

--- a/portal/tools/linetool.py
+++ b/portal/tools/linetool.py
@@ -43,7 +43,7 @@ class LineTool(BaseTool):
             self.canvas.drawing_context.pen_width,
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
-            wrap=False,
+            wrap=self.canvas.tile_preview_enabled,
         )
         painter.end()
         if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:

--- a/portal/tools/pentool.py
+++ b/portal/tools/pentool.py
@@ -112,7 +112,7 @@ class PenTool(BaseTool):
                 self.canvas.drawing_context.pen_width,
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
-                wrap=self.canvas.tile_preview_enabled,
+                wrap=False,
             )
         else:
             for i in range(len(self.points) - 1):
@@ -125,7 +125,7 @@ class PenTool(BaseTool):
                     self.canvas.drawing_context.pen_width,
                     self.canvas.drawing_context.mirror_x,
                     self.canvas.drawing_context.mirror_y,
-                    wrap=self.canvas.tile_preview_enabled,
+                    wrap=False,
                     erase=False,
                 )
 

--- a/portal/tools/pentool.py
+++ b/portal/tools/pentool.py
@@ -26,6 +26,12 @@ class PenTool(BaseTool):
         self.canvas.temp_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
         self.canvas.temp_image.fill(Qt.transparent)
 
+        if self.canvas.tile_preview_enabled:
+            self.canvas.tile_preview_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
+            self.canvas.tile_preview_image.fill(Qt.transparent)
+        else:
+            self.canvas.tile_preview_image = None
+
         # This flag tells the renderer to draw our temp_image ON TOP of the document, not instead of it.
         self.canvas.temp_image_replaces_active_layer = False
 
@@ -51,6 +57,7 @@ class PenTool(BaseTool):
             self.canvas.temp_image = None
             self.canvas.original_image = None
             self.canvas.temp_image_replaces_active_layer = False
+            self.canvas.tile_preview_image = None
             self.canvas.update()
             return
 
@@ -61,6 +68,7 @@ class PenTool(BaseTool):
             self.canvas.temp_image = None
             self.canvas.original_image = None
             self.canvas.temp_image_replaces_active_layer = False
+            self.canvas.tile_preview_image = None
             self.canvas.update()
             return
 
@@ -84,6 +92,7 @@ class PenTool(BaseTool):
         self.canvas.temp_image = None
         self.canvas.original_image = None
         self.canvas.temp_image_replaces_active_layer = False
+        self.canvas.tile_preview_image = None
         self.canvas.update()
 
     def draw_path_on_temp_image(self):
@@ -92,6 +101,8 @@ class PenTool(BaseTool):
 
         # Clear the temp image before redrawing the path
         self.canvas.temp_image.fill(Qt.transparent)
+        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
+            self.canvas.tile_preview_image.fill(Qt.transparent)
 
         painter = QPainter(self.canvas.temp_image)
 
@@ -130,4 +141,36 @@ class PenTool(BaseTool):
                 )
 
         painter.end()
+
+        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
+            preview_painter = QPainter(self.canvas.tile_preview_image)
+            if self.canvas.selection_shape:
+                preview_painter.setClipPath(self.canvas.selection_shape)
+            preview_painter.setPen(QPen(self.canvas.drawing_context.pen_color))
+            if len(self.points) == 1:
+                self.canvas.drawing.draw_brush(
+                    preview_painter,
+                    self.points[0],
+                    self.canvas._document_size,
+                    self.canvas.drawing_context.brush_type,
+                    self.canvas.drawing_context.pen_width,
+                    self.canvas.drawing_context.mirror_x,
+                    self.canvas.drawing_context.mirror_y,
+                    wrap=True,
+                )
+            else:
+                for i in range(len(self.points) - 1):
+                    self.canvas.drawing.draw_line_with_brush(
+                        preview_painter,
+                        self.points[i],
+                        self.points[i + 1],
+                        self.canvas._document_size,
+                        self.canvas.drawing_context.brush_type,
+                        self.canvas.drawing_context.pen_width,
+                        self.canvas.drawing_context.mirror_x,
+                        self.canvas.drawing_context.mirror_y,
+                        wrap=True,
+                        erase=False,
+                    )
+            preview_painter.end()
         

--- a/portal/tools/pentool.py
+++ b/portal/tools/pentool.py
@@ -123,7 +123,7 @@ class PenTool(BaseTool):
                 self.canvas.drawing_context.pen_width,
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
-                wrap=False,
+                wrap=self.canvas.tile_preview_enabled,
             )
         else:
             for i in range(len(self.points) - 1):
@@ -136,7 +136,7 @@ class PenTool(BaseTool):
                     self.canvas.drawing_context.pen_width,
                     self.canvas.drawing_context.mirror_x,
                     self.canvas.drawing_context.mirror_y,
-                    wrap=False,
+                    wrap=self.canvas.tile_preview_enabled,
                     erase=False,
                 )
 

--- a/portal/tools/rectangletool.py
+++ b/portal/tools/rectangletool.py
@@ -63,7 +63,7 @@ class RectangleTool(BaseTool):
             self.canvas.drawing_context.pen_width,
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
-            wrap=False,
+            wrap=self.canvas.tile_preview_enabled,
         )
         painter.end()
         if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:

--- a/portal/tools/rectangletool.py
+++ b/portal/tools/rectangletool.py
@@ -58,7 +58,7 @@ class RectangleTool(BaseTool):
             self.canvas.drawing_context.pen_width,
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
-            wrap=self.canvas.tile_preview_enabled,
+            wrap=False,
         )
         painter.end()
         self.canvas.update()

--- a/portal/tools/rectangletool.py
+++ b/portal/tools/rectangletool.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import QPoint, QRect
-from PySide6.QtGui import QMouseEvent, QPainter, QPen, Qt, QCursor
+from PySide6.QtGui import QMouseEvent, QPainter, QPen, Qt, QCursor, QImage
 
 from portal.tools.basetool import BaseTool
 from portal.core.command import ShapeCommand
@@ -24,6 +24,11 @@ class RectangleTool(BaseTool):
         self.start_point = doc_pos
         self.canvas.temp_image_replaces_active_layer = True
         self.command_generated.emit(("get_active_layer_image", "rectangle_tool_start"))
+        if self.canvas.tile_preview_enabled:
+            self.canvas.tile_preview_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
+            self.canvas.tile_preview_image.fill(Qt.transparent)
+        else:
+            self.canvas.tile_preview_image = None
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if self.canvas.original_image is None:
@@ -61,6 +66,23 @@ class RectangleTool(BaseTool):
             wrap=False,
         )
         painter.end()
+        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
+            self.canvas.tile_preview_image.fill(Qt.transparent)
+            preview_painter = QPainter(self.canvas.tile_preview_image)
+            if self.canvas.selection_shape:
+                preview_painter.setClipPath(self.canvas.selection_shape)
+            preview_painter.setPen(QPen(self.canvas.drawing_context.pen_color))
+            self.canvas.drawing.draw_rect(
+                preview_painter,
+                rect,
+                self.canvas._document_size,
+                self.canvas.drawing_context.brush_type,
+                self.canvas.drawing_context.pen_width,
+                self.canvas.drawing_context.mirror_x,
+                self.canvas.drawing_context.mirror_y,
+                wrap=True,
+            )
+            preview_painter.end()
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
@@ -100,4 +122,5 @@ class RectangleTool(BaseTool):
         self.canvas.temp_image = None
         self.canvas.original_image = None
         self.canvas.temp_image_replaces_active_layer = False
+        self.canvas.tile_preview_image = None
         self.canvas.update()

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -46,6 +46,7 @@ class Canvas(QWidget):
         self.temp_image = None
         self.temp_image_replaces_active_layer = False
         self.original_image = None
+        self.tile_preview_image = None
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.StrongFocus)
         self.background_pixmap = QPixmap("alphabg.png")


### PR DESCRIPTION
## Summary
- Prevent canvas input handler from wrapping coordinates while drawing
- Skip wrapping in tool previews and update line drawing to handle raw positions

## Testing
- `python -m py_compile portal/commands/canvas_input_handler.py portal/tools/linetool.py portal/tools/pentool.py portal/tools/erasertool.py portal/tools/rectangletool.py portal/tools/ellipsetool.py portal/core/drawing.py`


------
https://chatgpt.com/codex/tasks/task_e_68c787eb4a0483219870353f5591f308