### PR TITLE
Add extensible tool registry for tools

### DIFF
--- a/portal/commands/tool_bar_builder.py
+++ b/portal/commands/tool_bar_builder.py
@@ -71,8 +71,9 @@ class ToolBarBuilder:
         active_color_button.rightClicked.connect(self.main_window.add_color_to_palette)
         self.left_toolbar.addWidget(active_color_button)
 
-        from portal.tools import get_tools
-        tools = get_tools()
+        from portal.tools import registry
+
+        tools = registry.get_tools()
         self.tool_actions = {}
         self.tool_action_group = QActionGroup(self.main_window)
 

--- a/portal/tools/__init__.py
+++ b/portal/tools/__init__.py
@@ -1,33 +1,19 @@
-import os
-import importlib
-from portal.tools.basetool import BaseTool
+"""Tool registration and discovery utilities."""
+
+from .registry import ToolRegistry
+
+# Global registry instance used throughout the application
+registry = ToolRegistry()
+registry.load_builtin_tools()
+registry.load_external_tools()
+
+# Backwards compatible helper functions
+
+def register_tool(tool_cls):
+    registry.register_tool(tool_cls)
+
 
 def get_tools():
-    """
-    Dynamically discover and import all tool classes in this directory.
-    """
-    tools = []
-    tools_dir = os.path.dirname(__file__)
+    return registry.get_tools()
 
-    for filename in os.listdir(tools_dir):
-        if filename.endswith("tool.py") and filename != "basetool.py":
-            module_name = f"portal.tools.{filename[:-3]}"
-            module = importlib.import_module(module_name)
-            for attribute_name in dir(module):
-                attribute = getattr(module, attribute_name)
-                if (
-                    isinstance(attribute, type)
-                    and issubclass(attribute, BaseTool)
-                    and attribute is not BaseTool
-                    and getattr(attribute, "name", None)
-                ):
-                    tools.append(
-                        {
-                            "class": attribute,
-                            "name": attribute.name,
-                            "icon": getattr(attribute, "icon", None),
-                            "shortcut": getattr(attribute, "shortcut", None),
-                            "category": getattr(attribute, "category", None),
-                        }
-                    )
-    return tools
+__all__ = ["ToolRegistry", "registry", "register_tool", "get_tools"]

--- a/portal/tools/registry.py
+++ b/portal/tools/registry.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib
+import os
+from importlib.metadata import entry_points
+from typing import Dict, List, Type
+
+from .basetool import BaseTool
+
+
+class ToolRegistry:
+    """Registry for built-in and external tools."""
+
+    def __init__(self) -> None:
+        self._tools: List[Dict] = []
+
+    # ------------------------------------------------------------------
+    def register_tool(self, tool_cls: Type[BaseTool]) -> None:
+        """Register a :class:`BaseTool` subclass.
+
+        Parameters
+        ----------
+        tool_cls:
+            The tool class to register.
+        """
+
+        if not isinstance(tool_cls, type) or not issubclass(tool_cls, BaseTool):
+            raise TypeError("tool_cls must be a subclass of BaseTool")
+        if tool_cls is BaseTool:
+            return
+        if not getattr(tool_cls, "name", None):
+            return
+        # Avoid duplicates
+        if any(t["class"] is tool_cls for t in self._tools):
+            return
+        self._tools.append(
+            {
+                "class": tool_cls,
+                "name": tool_cls.name,
+                "icon": getattr(tool_cls, "icon", None),
+                "shortcut": getattr(tool_cls, "shortcut", None),
+                "category": getattr(tool_cls, "category", None),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    def get_tools(self) -> List[Dict]:
+        """Return registered tools."""
+
+        return list(self._tools)
+
+    # ------------------------------------------------------------------
+    def load_builtin_tools(self) -> None:
+        """Discover and register built-in tools located in this package."""
+
+        tools_dir = os.path.dirname(__file__)
+        for filename in os.listdir(tools_dir):
+            if not filename.endswith("tool.py"):
+                continue
+            if filename in {"basetool.py", "registry.py"}:
+                continue
+            module_name = f"{__package__}.{filename[:-3]}"
+            module = importlib.import_module(module_name)
+            for attr_name in dir(module):
+                attr = getattr(module, attr_name)
+                if (
+                    isinstance(attr, type)
+                    and issubclass(attr, BaseTool)
+                    and attr is not BaseTool
+                    and getattr(attr, "name", None)
+                ):
+                    self.register_tool(attr)
+
+    # ------------------------------------------------------------------
+    def load_external_tools(self) -> None:
+        """Load tools provided by external packages via entry points."""
+
+        try:
+            eps = entry_points(group="pixel_portal.tools")
+        except TypeError:  # Python < 3.10 compatibility
+            eps = entry_points().get("pixel_portal.tools", [])
+        for ep in eps:
+            try:
+                tool_cls = ep.load()
+                self.register_tool(tool_cls)
+            except Exception:
+                # Ignore badly defined entry points
+                continue
+
+
+__all__ = ["ToolRegistry"]

--- a/tests/test_tool_bar_builder.py
+++ b/tests/test_tool_bar_builder.py
@@ -33,7 +33,9 @@ def test_toolbar_groups_tools_by_category(qapp, monkeypatch):
         shortcut = "3"
         category = "select"
 
-    from portal.tools import get_tools as real_get_tools
+    from portal.tools import registry as tool_registry
+
+    real_get_tools = tool_registry.get_tools
 
     def fake_get_tools():
         tools = real_get_tools()
@@ -64,7 +66,7 @@ def test_toolbar_groups_tools_by_category(qapp, monkeypatch):
         )
         return tools
 
-    monkeypatch.setattr("portal.tools.get_tools", fake_get_tools)
+    monkeypatch.setattr(tool_registry, "get_tools", fake_get_tools)
 
     builder._setup_left_toolbar()
 


### PR DESCRIPTION
## Summary
- Implement a `ToolRegistry` that discovers built-in tools and loads external ones via `pixel_portal.tools` entry points.
- Initialize and expose the registry in `portal.tools` with backward-compatible helpers.
- Update toolbar builder and tests to retrieve tool metadata through the registry.

## Testing
- `python -m py_compile portal/tools/registry.py portal/tools/__init__.py portal/commands/tool_bar_builder.py tests/test_tool_bar_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7940907a88321920aba803b13a6e6