### PR TITLE
feat: add pattern brush creation

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -77,6 +77,9 @@ class ActionManager:
         self.clear_action.setShortcut(QKeySequence.Delete)
         self.clear_action.triggered.connect(self.app.clear_layer)
 
+        self.create_brush_action = QAction("Create Brush", self.main_window)
+        self.create_brush_action.triggered.connect(self.app.create_brush)
+
     def _build_select_actions(self):
         """Create actions for selection manipulation."""
         self.select_all_action = QAction("Select &All", self.main_window)

--- a/portal/commands/menu_bar_builder.py
+++ b/portal/commands/menu_bar_builder.py
@@ -42,6 +42,7 @@ class MenuBarBuilder:
         edit_menu.addAction(self.action_manager.paste_action)
         edit_menu.addSeparator()
         edit_menu.addAction(self.action_manager.paste_as_new_image_action)
+        edit_menu.addAction(self.action_manager.create_brush_action)
         edit_menu.addSeparator()
         edit_menu.addAction(self.action_manager.flip_action)
         edit_menu.addSeparator()

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -167,6 +167,10 @@ class App(QObject):
     def add_new_layer_with_image(self, image):
         self.document_controller.add_new_layer_with_image(image)
 
+    @Slot()
+    def create_brush(self):
+        self.document_controller.create_brush()
+
     @Slot(object)
     def handle_command(self, command):
         self.document_controller.handle_command(command)

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -179,3 +179,14 @@ class DocumentController(QObject):
 
     def get_current_image(self):
         return self.document.get_current_image_for_ai()
+
+    @Slot()
+    def create_brush(self):
+        if not self.main_window:
+            return
+        selection = self.main_window.canvas.selection_shape if self.main_window.canvas else None
+        image = self.document.render()
+        if selection and not selection.isEmpty():
+            rect = selection.boundingRect().toRect()
+            image = image.copy(rect)
+        self.drawing_context.set_pattern_brush(image)

--- a/portal/core/drawing_context.py
+++ b/portal/core/drawing_context.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import QObject, Signal, Slot
-from PySide6.QtGui import QColor
+from PySide6.QtGui import QColor, QImage
 
 
 class DrawingContext(QObject):
@@ -9,6 +9,7 @@ class DrawingContext(QObject):
     brush_type_changed = Signal(str)
     mirror_x_changed = Signal(bool)
     mirror_y_changed = Signal(bool)
+    pattern_brush_changed = Signal(object)
 
     def __init__(self):
         super().__init__()
@@ -17,6 +18,7 @@ class DrawingContext(QObject):
         self.pen_color = QColor("black")
         self.pen_width = 1
         self.brush_type = "Circular"
+        self.pattern_brush: QImage | None = None
         self.mirror_x = False
         self.mirror_y = False
 
@@ -55,3 +57,9 @@ class DrawingContext(QObject):
         else:
             self.pen_color = color
         self.pen_color_changed.emit(self.pen_color)
+
+    @Slot(QImage)
+    def set_pattern_brush(self, image):
+        self.pattern_brush = image
+        self.pattern_brush_changed.emit(self.pattern_brush)
+        self.set_brush_type("Pattern")


### PR DESCRIPTION
## Summary
- add pattern brush support in DrawingContext with new signal
- enable brush creation from selection via DocumentController and App
- add UI action to create brushes

## Testing
- `python -m py_compile portal/core/drawing_context.py portal/core/document_controller.py portal/core/app.py portal/commands/action_manager.py portal/commands/menu_bar_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68c825d9f2808321bd24f3b7df0fa671