### PR TITLE
Add pattern brush support to drawing commands and previews

### DIFF
--- a/portal/tools/ellipsetool.py
+++ b/portal/tools/ellipsetool.py
@@ -65,6 +65,7 @@ class EllipseTool(BaseTool):
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
             wrap=self.canvas.tile_preview_enabled,
+            pattern=self.canvas.drawing_context.pattern_brush,
         )
         painter.end()
         if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
@@ -82,6 +83,7 @@ class EllipseTool(BaseTool):
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
                 wrap=True,
+                pattern=self.canvas.drawing_context.pattern_brush,
             )
             preview_painter.end()
         self.canvas.update()
@@ -117,6 +119,8 @@ class EllipseTool(BaseTool):
             mirror_x=self.canvas.drawing_context.mirror_x,
             mirror_y=self.canvas.drawing_context.mirror_y,
             wrap=self.canvas.tile_preview_enabled,
+            brush_type=self.canvas.drawing_context.brush_type,
+            pattern_image=self.canvas.drawing_context.pattern_brush,
         )
         self.command_generated.emit(command)
 

--- a/portal/tools/linetool.py
+++ b/portal/tools/linetool.py
@@ -44,6 +44,7 @@ class LineTool(BaseTool):
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
             wrap=self.canvas.tile_preview_enabled,
+            pattern=self.canvas.drawing_context.pattern_brush,
         )
         painter.end()
         if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
@@ -62,6 +63,7 @@ class LineTool(BaseTool):
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
                 wrap=True,
+                pattern=self.canvas.drawing_context.pattern_brush,
             )
             preview_painter.end()
         self.canvas.update()
@@ -86,6 +88,7 @@ class LineTool(BaseTool):
             mirror_x=self.canvas.drawing_context.mirror_x,
             mirror_y=self.canvas.drawing_context.mirror_y,
             wrap=self.canvas.tile_preview_enabled,
+            pattern_image=self.canvas.drawing_context.pattern_brush,
         )
         self.command_generated.emit(command)
 

--- a/portal/tools/pentool.py
+++ b/portal/tools/pentool.py
@@ -84,6 +84,7 @@ class PenTool(BaseTool):
             mirror_x=self.canvas.drawing_context.mirror_x,
             mirror_y=self.canvas.drawing_context.mirror_y,
             wrap=self.canvas.tile_preview_enabled,
+            pattern_image=self.canvas.drawing_context.pattern_brush,
         )
         self.command_generated.emit(command)
 
@@ -124,6 +125,7 @@ class PenTool(BaseTool):
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
                 wrap=self.canvas.tile_preview_enabled,
+                pattern=self.canvas.drawing_context.pattern_brush,
             )
         else:
             for i in range(len(self.points) - 1):
@@ -138,6 +140,7 @@ class PenTool(BaseTool):
                     self.canvas.drawing_context.mirror_y,
                     wrap=self.canvas.tile_preview_enabled,
                     erase=False,
+                    pattern=self.canvas.drawing_context.pattern_brush,
                 )
 
         painter.end()
@@ -157,6 +160,7 @@ class PenTool(BaseTool):
                     self.canvas.drawing_context.mirror_x,
                     self.canvas.drawing_context.mirror_y,
                     wrap=True,
+                    pattern=self.canvas.drawing_context.pattern_brush,
                 )
             else:
                 for i in range(len(self.points) - 1):
@@ -171,6 +175,7 @@ class PenTool(BaseTool):
                         self.canvas.drawing_context.mirror_y,
                         wrap=True,
                         erase=False,
+                        pattern=self.canvas.drawing_context.pattern_brush,
                     )
             preview_painter.end()
         

--- a/portal/tools/rectangletool.py
+++ b/portal/tools/rectangletool.py
@@ -64,6 +64,7 @@ class RectangleTool(BaseTool):
             self.canvas.drawing_context.mirror_x,
             self.canvas.drawing_context.mirror_y,
             wrap=self.canvas.tile_preview_enabled,
+            pattern=self.canvas.drawing_context.pattern_brush,
         )
         painter.end()
         if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
@@ -81,6 +82,7 @@ class RectangleTool(BaseTool):
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
                 wrap=True,
+                pattern=self.canvas.drawing_context.pattern_brush,
             )
             preview_painter.end()
         self.canvas.update()
@@ -116,6 +118,8 @@ class RectangleTool(BaseTool):
             mirror_x=self.canvas.drawing_context.mirror_x,
             mirror_y=self.canvas.drawing_context.mirror_y,
             wrap=self.canvas.tile_preview_enabled,
+            brush_type=self.canvas.drawing_context.brush_type,
+            pattern_image=self.canvas.drawing_context.pattern_brush,
         )
         self.command_generated.emit(command)
 


### PR DESCRIPTION
## Summary
- add optional pattern image support to the core drawing helpers and DrawCommand so pattern brushes stamp correctly
- update DrawCommand and ShapeCommand to carry pattern metadata and enlarge buffers for patterned strokes
- use the selected pattern for live previews and command execution in the pen, line, rectangle, and ellipse tools

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c837b11ef48321953d1bdf0618354b