### PR TITLE
Add headless requirements file and update guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 # Instructions for AI Agents
 
+## Environment Setup for Unix/Test/Headless Runs
+
+Use `requirements-headless.txt` when preparing a Unix, CI, or other headless/testing environment. This trimmed requirements file omits AI-specific dependencies (such as PyTorch and the diffusion stack) that are not required for automated testing. Install it with:
+
+```bash
+pip install -r requirements-headless.txt
+```
+
 ## Running Tests
 
 **Important:** Do not run any tests unless explicitly asked to do so.

--- a/requirements-headless.txt
+++ b/requirements-headless.txt
@@ -1,0 +1,5 @@
+PySide6
+pytest-qt
+Pillow
+numpy
+scikit-learn


### PR DESCRIPTION
## Summary
- add a dedicated requirements file for Unix/headless testing environments without AI dependencies
- update the agent instructions to reference the new lightweight requirements file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c84a3cfc00832191855d42ac32a811