### PR TITLE
Add settings dialog for grid configuration

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -80,6 +80,10 @@ class ActionManager:
         self.create_brush_action = QAction("Create Brush", self.main_window)
         self.create_brush_action.triggered.connect(self.app.create_brush)
 
+        self.settings_action = QAction("Settings...", self.main_window)
+        self.settings_action.setShortcut("Ctrl+,")
+        self.settings_action.triggered.connect(self.main_window.open_settings_dialog)
+
     def _build_select_actions(self):
         """Create actions for selection manipulation."""
         self.select_all_action = QAction("Select &All", self.main_window)

--- a/portal/commands/menu_bar_builder.py
+++ b/portal/commands/menu_bar_builder.py
@@ -46,6 +46,7 @@ class MenuBarBuilder:
         edit_menu.addSeparator()
         edit_menu.addAction(self.action_manager.flip_action)
         edit_menu.addSeparator()
+        edit_menu.addAction(self.action_manager.settings_action)
 
         select_menu = menu_bar.addMenu("&Select")
         select_menu.addAction(self.action_manager.select_all_action)

--- a/portal/core/renderer.py
+++ b/portal/core/renderer.py
@@ -244,6 +244,12 @@ class CanvasRenderer:
         if self.canvas.zoom < 2 or not self.canvas.grid_visible:
             return
 
+        major_visible = self.canvas.grid_major_visible and self.canvas.grid_major_spacing > 0
+        minor_visible = self.canvas.grid_minor_visible and self.canvas.grid_minor_spacing > 0
+
+        if not major_visible and not minor_visible:
+            return
+
         doc_width = self.canvas._document_size.width()
         doc_height = self.canvas._document_size.height()
 
@@ -253,6 +259,9 @@ class CanvasRenderer:
         minor_color.setAlpha(100)
         major_color = palette.color(QPalette.ColorRole.Text)
         major_color.setAlpha(100)
+
+        major_spacing = max(1, int(self.canvas.grid_major_spacing))
+        minor_spacing = max(1, int(self.canvas.grid_minor_spacing))
 
         # Find the range of document coordinates currently visible on the canvas
         doc_top_left = self.canvas.get_doc_coords(QPoint(0, 0))
@@ -268,10 +277,16 @@ class CanvasRenderer:
         # Draw vertical lines
         for dx in range(start_x, end_x + 1):
             canvas_x = target_rect.x() + dx * self.canvas.zoom
-            if dx % 8 == 0:
-                painter.setPen(major_color)
-            else:
-                painter.setPen(minor_color)
+            pen = None
+            if major_visible and dx % major_spacing == 0:
+                pen = major_color
+            elif minor_visible and dx % minor_spacing == 0:
+                pen = minor_color
+
+            if pen is None:
+                continue
+
+            painter.setPen(pen)
             painter.drawLine(
                 round(canvas_x),
                 target_rect.top(),
@@ -282,10 +297,16 @@ class CanvasRenderer:
         # Draw horizontal lines
         for dy in range(start_y, end_y + 1):
             canvas_y = target_rect.y() + dy * self.canvas.zoom
-            if dy % 8 == 0:
-                painter.setPen(major_color)
-            else:
-                painter.setPen(minor_color)
+            pen = None
+            if major_visible and dy % major_spacing == 0:
+                pen = major_color
+            elif minor_visible and dy % minor_spacing == 0:
+                pen = minor_color
+
+            if pen is None:
+                continue
+
+            painter.setPen(pen)
             painter.drawLine(
                 target_rect.left(),
                 round(canvas_y),

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -53,6 +53,10 @@ class Canvas(QWidget):
         self.cursor_doc_pos = QPoint()
         self.mouse_over_canvas = False
         self.grid_visible = False
+        self.grid_major_visible = True
+        self.grid_minor_visible = True
+        self.grid_major_spacing = 8
+        self.grid_minor_spacing = 1
         self.tile_preview_enabled = False
         self.tile_preview_rows = 3
         self.tile_preview_cols = 3
@@ -238,6 +242,32 @@ class Canvas(QWidget):
     def toggle_grid(self):
         self.grid_visible = not self.grid_visible
         self.update()
+
+    def set_grid_settings(
+        self,
+        *,
+        major_visible=None,
+        major_spacing=None,
+        minor_visible=None,
+        minor_spacing=None,
+    ):
+        if major_visible is not None:
+            self.grid_major_visible = bool(major_visible)
+        if major_spacing is not None:
+            self.grid_major_spacing = max(1, int(major_spacing))
+        if minor_visible is not None:
+            self.grid_minor_visible = bool(minor_visible)
+        if minor_spacing is not None:
+            self.grid_minor_spacing = max(1, int(minor_spacing))
+        self.update()
+
+    def get_grid_settings(self):
+        return {
+            "major_visible": self.grid_major_visible,
+            "major_spacing": self.grid_major_spacing,
+            "minor_visible": self.grid_minor_visible,
+            "minor_spacing": self.grid_minor_spacing,
+        }
 
     def resizeEvent(self, event):
         # The canvas widget has been resized.

--- a/portal/ui/settings_dialog.py
+++ b/portal/ui/settings_dialog.py
@@ -1,0 +1,85 @@
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class SettingsDialog(QDialog):
+    """Dialog for configuring application settings."""
+
+    def __init__(self, settings_controller, parent=None):
+        super().__init__(parent)
+        self.settings_controller = settings_controller
+
+        self.setWindowTitle("Settings")
+
+        layout = QVBoxLayout(self)
+
+        self.tab_widget = QTabWidget(self)
+        layout.addWidget(self.tab_widget)
+
+        self._build_grid_tab()
+
+        self.button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+        self._apply_settings_to_widgets()
+
+    def _build_grid_tab(self):
+        grid_tab = QWidget(self)
+        grid_layout = QGridLayout(grid_tab)
+        grid_layout.setColumnStretch(0, 1)
+
+        self.major_grid_checkbox = QCheckBox("Show major grid lines", grid_tab)
+        self.major_grid_spacing = QSpinBox(grid_tab)
+        self.major_grid_spacing.setMinimum(1)
+        self.major_grid_spacing.setMaximum(1024)
+        self.major_grid_spacing.setEnabled(self.major_grid_checkbox.isChecked())
+        self.major_grid_checkbox.toggled.connect(self.major_grid_spacing.setEnabled)
+
+        self.minor_grid_checkbox = QCheckBox("Show minor grid lines", grid_tab)
+        self.minor_grid_spacing = QSpinBox(grid_tab)
+        self.minor_grid_spacing.setMinimum(1)
+        self.minor_grid_spacing.setMaximum(1024)
+        self.minor_grid_spacing.setEnabled(self.minor_grid_checkbox.isChecked())
+        self.minor_grid_checkbox.toggled.connect(self.minor_grid_spacing.setEnabled)
+
+        grid_layout.addWidget(self.major_grid_checkbox, 0, 0)
+        grid_layout.addWidget(QLabel("Spacing (px)", grid_tab), 0, 1)
+        grid_layout.addWidget(self.major_grid_spacing, 0, 2)
+
+        grid_layout.addWidget(self.minor_grid_checkbox, 1, 0)
+        grid_layout.addWidget(QLabel("Spacing (px)", grid_tab), 1, 1)
+        grid_layout.addWidget(self.minor_grid_spacing, 1, 2)
+
+        self.tab_widget.addTab(grid_tab, "Grid")
+
+    def _apply_settings_to_widgets(self):
+        grid_settings = self.settings_controller.get_grid_settings()
+        self.major_grid_checkbox.setChecked(grid_settings["major_visible"])
+        self.major_grid_spacing.setValue(grid_settings["major_spacing"])
+        self.minor_grid_checkbox.setChecked(grid_settings["minor_visible"])
+        self.minor_grid_spacing.setValue(grid_settings["minor_spacing"])
+
+    def get_grid_settings(self):
+        return {
+            "major_visible": self.major_grid_checkbox.isChecked(),
+            "major_spacing": self.major_grid_spacing.value(),
+            "minor_visible": self.minor_grid_checkbox.isChecked(),
+            "minor_spacing": self.minor_grid_spacing.value(),
+        }
+
+    def accept(self):
+        self.settings_controller.update_grid_settings(**self.get_grid_settings())
+        super().accept()

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -18,6 +18,7 @@ from portal.commands.menu_bar_builder import MenuBarBuilder
 from portal.commands.tool_bar_builder import ToolBarBuilder
 from portal.commands.status_bar_manager import StatusBarManager
 from portal.ui.flip_dialog import FlipDialog
+from portal.ui.settings_dialog import SettingsDialog
 
 
 from PySide6.QtWidgets import QMainWindow, QLabel, QToolBar, QPushButton, QWidget, QGridLayout, QDockWidget, QSlider, QColorDialog
@@ -38,6 +39,7 @@ class MainWindow(QMainWindow):
         self.canvas = Canvas(self.app.drawing_context)
         self.setCentralWidget(self.canvas)
         self.canvas.set_document(self.app.document)
+        self.apply_grid_settings_from_settings()
 
         # Connect DrawingContext signals to Canvas slots
         self.app.drawing_context.tool_changed.connect(self.canvas.on_tool_changed)
@@ -302,6 +304,12 @@ class MainWindow(QMainWindow):
                 values = dialog.get_values()
                 self.app.resize_document(values["width"], values["height"], values["interpolation"])
 
+    def open_settings_dialog(self):
+        dialog = SettingsDialog(self.app.settings_controller, self)
+        if dialog.exec():
+            self.canvas.set_grid_settings(**self.app.settings_controller.get_grid_settings())
+            self.app.save_settings()
+
     def open_background_color_dialog(self):
         color = QColorDialog.getColor(self.canvas.background_color, self)
         if color.isValid():
@@ -331,6 +339,9 @@ class MainWindow(QMainWindow):
             if dialog.exec():
                 values = dialog.get_values()
                 self.app.flip(values["horizontal"], values["vertical"], values["all_layers"])
+
+    def apply_grid_settings_from_settings(self):
+        self.canvas.set_grid_settings(**self.app.settings_controller.get_grid_settings())
 
     def get_palette(self):
         return [button.color for button in self.main_palette_buttons]


### PR DESCRIPTION
## Summary
- add an Edit ▸ Settings menu item and dialog with grid visibility checkboxes and spacing inputs
- persist grid preferences through the SettingsController and apply them to the canvas
- update grid rendering to honor configurable major and minor spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c85ec3a1f08321b73c40b367cda27a