### PR TITLE
Support expanding canvas to oversized selections

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -100,7 +100,7 @@ class ActionManager:
         self.resize_action.setShortcut("Ctrl+R")
         self.resize_action.triggered.connect(self.main_window.open_resize_dialog)
 
-        self.crop_action = QAction("Crop to Selection", self.main_window)
+        self.crop_action = QAction("Fit Canvas to Selection", self.main_window)
         self.crop_action.triggered.connect(self.app.crop_to_selection)
         self.crop_action.setEnabled(False)
 

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -106,8 +106,17 @@ class Document:
             layer.on_image_change.emit()
 
     def crop(self, rect):
-        self.width = rect.width()
-        self.height = rect.height()
+        rect = rect.normalized()
+        if rect.width() <= 0 or rect.height() <= 0:
+            return
+
+        new_width = rect.width()
+        new_height = rect.height()
+
+        self.width = new_width
+        self.height = new_height
+        self.layer_manager.width = new_width
+        self.layer_manager.height = new_height
 
         for layer in self.layer_manager.layers:
             layer.image = layer.image.copy(rect)

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -130,9 +130,36 @@ def test_crop(document):
 
     assert document.width == crop_rect.width()
     assert document.height == crop_rect.height()
+    assert document.layer_manager.width == crop_rect.width()
+    assert document.layer_manager.height == crop_rect.height()
     for layer in document.layer_manager.layers:
         assert layer.image.width() == crop_rect.width()
         assert layer.image.height() == crop_rect.height()
+
+
+def test_crop_expands_document_when_selection_is_larger():
+    """Cropping with a selection larger than the document should expand the canvas."""
+    doc = Document(10, 10)
+    base_layer = doc.layer_manager.layers[0]
+    base_layer.image.fill(QColor(0, 0, 0, 0))
+    base_layer.image.setPixelColor(0, 0, QColor("red"))
+
+    selection_rect = QRect(-5, -3, 20, 20)
+    doc.crop(selection_rect)
+
+    assert doc.width == selection_rect.width()
+    assert doc.height == selection_rect.height()
+    assert doc.layer_manager.width == selection_rect.width()
+    assert doc.layer_manager.height == selection_rect.height()
+
+    assert base_layer.image.width() == selection_rect.width()
+    assert base_layer.image.height() == selection_rect.height()
+    assert base_layer.image.pixelColor(5, 3) == QColor("red")
+
+    doc.layer_manager.add_layer("Post Crop")
+    new_layer = doc.layer_manager.active_layer
+    assert new_layer.image.width() == selection_rect.width()
+    assert new_layer.image.height() == selection_rect.height()
 
 
 def test_set_layer_opacity_command(document):


### PR DESCRIPTION
## Summary
- update document cropping to normalize the selection, sync layer-manager dimensions, and permit expanding beyond the original canvas
- rename the image menu action to "Fit Canvas to Selection" so the UI reflects the broader resize behaviour
- extend the document/layer tests to cover layer-manager sizing and canvas expansion after cropping

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c8614f80488321932e4bf492c2485e