### PR TITLE
feat: allow image background

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Pixel-Portal is a lightweight, cross-platform image editor built with Python and
 - **Image Manipulation**: Resize, crop, and flip the canvas.
 - **AI-Powered Image Generation**: Integrated with state-of-the-art AI models to generate images from text prompts.
 - **Optional Background Removal**: Strip backgrounds from generated images using `rembg` (requires `onnxruntime`).
+- **Background Options**: Choose checkered, solid colors, or a custom image for the canvas background.
 - **Undo/Redo**: A robust undo/redo system to make editing easier and non-destructive.
 - **Customizable Interface**: A simple and intuitive interface that can be customized to your liking.
 

--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -137,6 +137,9 @@ class ActionManager:
         self.custom_color_action = QAction("Custom Color...", self.main_window)
         self.custom_color_action.triggered.connect(self.main_window.open_background_color_dialog)
 
+        self.image_background_action = QAction("Image...", self.main_window)
+        self.image_background_action.triggered.connect(self.main_window.open_background_image_dialog)
+
         self.tile_preview_action = QAction("Tile Preview", self.main_window)
         self.tile_preview_action.setCheckable(True)
         self.tile_preview_action.toggled.connect(canvas.toggle_tile_preview)

--- a/portal/commands/menu_bar_builder.py
+++ b/portal/commands/menu_bar_builder.py
@@ -69,6 +69,7 @@ class MenuBarBuilder:
         background_menu.addAction(self.action_manager.magenta_action)
         background_menu.addSeparator()
         background_menu.addAction(self.action_manager.custom_color_action)
+        background_menu.addAction(self.action_manager.image_background_action)
 
         view_menu.addSeparator()
         view_menu.addAction(self.action_manager.tile_preview_action)

--- a/portal/core/renderer.py
+++ b/portal/core/renderer.py
@@ -119,7 +119,9 @@ class CanvasRenderer:
         painter.restore()
 
     def _draw_background(self, painter, target_rect):
-        if self.canvas.background.is_checkered:
+        if self.canvas.background_image:
+            painter.drawPixmap(target_rect, self.canvas.background_image)
+        elif self.canvas.background.is_checkered:
             brush = QBrush(self.canvas.background_pixmap)
             transform = QTransform()
             transform.translate(target_rect.x(), target_rect.y())

--- a/portal/ui/background.py
+++ b/portal/ui/background.py
@@ -2,9 +2,10 @@ from PySide6.QtGui import QColor
 
 
 class Background:
-    def __init__(self, color=None):
+    def __init__(self, color=None, image_path=None):
         self.color = color
+        self.image_path = image_path
 
     @property
     def is_checkered(self):
-        return self.color is None
+        return self.color is None and self.image_path is None

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -50,6 +50,7 @@ class Canvas(QWidget):
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.StrongFocus)
         self.background_pixmap = QPixmap("alphabg.png")
+        self.background_image = None
         self.cursor_doc_pos = QPoint()
         self.mouse_over_canvas = False
         self.grid_visible = False
@@ -86,6 +87,10 @@ class Canvas(QWidget):
 
     def set_background(self, background: Background):
         self.background = background
+        if background.image_path:
+            self.background_image = QPixmap(background.image_path)
+        else:
+            self.background_image = None
         self.update()
 
     @Slot(bool)

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -307,6 +307,18 @@ class MainWindow(QMainWindow):
         if color.isValid():
             self.canvas.set_background(Background(color))
 
+    def open_background_image_dialog(self):
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open Background Image",
+            self.app.last_directory,
+            "Image Files (*.png *.jpg *.bmp)",
+        )
+        if file_path:
+            self.app.last_directory = os.path.dirname(file_path)
+            self.app.config.set('General', 'last_directory', self.app.last_directory)
+            self.canvas.set_background(Background(image_path=file_path))
+
     def update_crop_action_state(self, has_selection):
         self.action_manager.crop_action.setEnabled(has_selection)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -280,6 +280,7 @@ def mock_main_window(qapp):
     window.save_palette_as_png = MagicMock()
     window.open_resize_dialog = MagicMock()
     window.open_background_color_dialog = MagicMock()
+    window.open_background_image_dialog = MagicMock()
     window.toggle_ai_panel = MagicMock()
     window.open_flip_dialog = MagicMock()
     return window
@@ -316,6 +317,7 @@ def test_setup_actions(mock_main_window):
     assert action_manager.gray_action is not None
     assert action_manager.magenta_action is not None
     assert action_manager.custom_color_action is not None
+    assert action_manager.image_background_action is not None
     assert action_manager.circular_brush_action is not None
     assert action_manager.square_brush_action is not None
     assert action_manager.mirror_x_action is not None
@@ -371,6 +373,9 @@ def test_setup_actions(mock_main_window):
 
     action_manager.custom_color_action.trigger()
     mock_main_window.open_background_color_dialog.assert_called_once()
+
+    action_manager.image_background_action.trigger()
+    mock_main_window.open_background_image_dialog.assert_called_once()
 
     action_manager.mirror_x_action.trigger()
     mock_main_window.app.set_mirror_x.assert_called_once()

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -563,6 +563,16 @@ def test_set_background(canvas):
     canvas.set_background(background)
     assert canvas.background == background
 
+
+def test_set_background_image(canvas):
+    """Test that an image can be used as the background."""
+    from portal.ui.background import Background
+    image_path = os.path.join(os.path.dirname(__file__), "..", "alphabg.png")
+    background = Background(image_path=image_path)
+    canvas.set_background(background)
+    assert canvas.background == background
+    assert canvas.background_image is not None
+
 def test_select_all(canvas):
     """Test that a selection is created for the entire document."""
     from PySide6.QtCore import QRect


### PR DESCRIPTION
## Summary
- support custom image files as canvas backgrounds
- expose new background image action and menu entry
- document background options and add tests

## Testing
- `python -m py_compile portal/ui/background.py portal/ui/canvas.py portal/core/renderer.py portal/commands/action_manager.py portal/commands/menu_bar_builder.py portal/ui/ui.py tests/test_core.py tests/test_document_and_layers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8254147f483219819e2c59c0832a8