### PR TITLE
Add Select Opaque menu action

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -99,6 +99,9 @@ class ActionManager:
         self.invert_selection_action.setShortcut("Ctrl+I")
         self.invert_selection_action.triggered.connect(self.app.invert_selection)
 
+        self.select_opaque_action = QAction("Select &Opaque", self.main_window)
+        self.select_opaque_action.triggered.connect(self.app.select_opaque)
+
     def _build_image_actions(self):
         """Create actions that modify the current image."""
         self.resize_action = QAction(QIcon("icons/resize.png"), "&Resize", self.main_window)

--- a/portal/commands/menu_bar_builder.py
+++ b/portal/commands/menu_bar_builder.py
@@ -52,6 +52,7 @@ class MenuBarBuilder:
         select_menu.addAction(self.action_manager.select_all_action)
         select_menu.addAction(self.action_manager.select_none_action)
         select_menu.addAction(self.action_manager.invert_selection_action)
+        select_menu.addAction(self.action_manager.select_opaque_action)
 
         image_menu = menu_bar.addMenu("&Image")
         image_menu.addAction(self.action_manager.resize_action)

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -144,19 +144,17 @@ class App(QObject):
 
     @Slot()
     def select_opaque(self):
-        if not self.main_window:
-            return
-
         document = getattr(self, "document", None)
-        if document is None:
-            return
-
         layer_manager = getattr(document, "layer_manager", None)
-        if layer_manager is None:
-            return
+        active_layer = getattr(layer_manager, "active_layer", None)
+        self._select_opaque_for_layer(active_layer)
 
-        layer = layer_manager.active_layer
-        if layer is None:
+    def select_opaque_for_layer(self, layer):
+        """Select opaque pixels for a specific layer without changing state."""
+        self._select_opaque_for_layer(layer)
+
+    def _select_opaque_for_layer(self, layer):
+        if not self.main_window or layer is None:
             return
 
         canvas = getattr(self.main_window, "canvas", None)

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -143,6 +143,32 @@ class App(QObject):
         self.invert_selection_triggered.emit()
 
     @Slot()
+    def select_opaque(self):
+        if not self.main_window:
+            return
+
+        document = getattr(self, "document", None)
+        if document is None:
+            return
+
+        layer_manager = getattr(document, "layer_manager", None)
+        if layer_manager is None:
+            return
+
+        layer = layer_manager.active_layer
+        if layer is None:
+            return
+
+        canvas = getattr(self.main_window, "canvas", None)
+        if canvas is None:
+            return
+
+        from portal.commands.selection_commands import SelectOpaqueCommand
+
+        command = SelectOpaqueCommand(layer, canvas)
+        self.execute_command(command)
+
+    @Slot()
     def clear_layer(self):
         self.clear_layer_triggered.emit()
 

--- a/portal/ui/layer_list_widget.py
+++ b/portal/ui/layer_list_widget.py
@@ -35,6 +35,21 @@ class LayerListWidget(QListWidget):
         elif action == remove_bg_action:
             self.remove_background_requested.emit(index)
 
+    def mousePressEvent(self, event):
+        if (
+            event.button() == Qt.LeftButton
+            and event.modifiers() & Qt.ControlModifier
+        ):
+            # Ctrl+click selects opaque pixels on the clicked layer without
+            # changing which layer is active.
+            item = self.itemAt(event.position().toPoint())
+            if item:
+                self.select_opaque_requested.emit(self.row(item))
+            event.accept()
+            return
+
+        super().mousePressEvent(event)
+
     def startDrag(self, supportedActions):
         if QApplication.keyboardModifiers() & Qt.ControlModifier:
             # Ctrl is pressed, so don't start the drag.

--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -197,9 +197,7 @@ class LayerManagerWidget(QWidget):
     def select_opaque(self, index_in_list):
         actual_index = len(self.app.document.layer_manager.layers) - 1 - index_in_list
         layer = self.app.document.layer_manager.layers[actual_index]
-        from portal.commands.selection_commands import SelectOpaqueCommand
-        command = SelectOpaqueCommand(layer, self.canvas)
-        self.app.execute_command(command)
+        self.app.select_opaque_for_layer(layer)
 
     def duplicate_layer_from_menu(self, index_in_list):
         actual_index = len(self.app.document.layer_manager.layers) - 1 - index_in_list


### PR DESCRIPTION
## Summary
- expose a Select Opaque action through the Select menu
- implement the action via App.select_opaque so the active layer's opaque pixels become the selection

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c8a3787e1c8321b4c989d961b1287a