### PR TITLE
Add toolbar layout config for left tools

### DIFF
--- a/portal/config/__init__.py
+++ b/portal/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration data for Pixel Portal."""

--- a/portal/config/toolbar_tools.json
+++ b/portal/config/toolbar_tools.json
@@ -1,0 +1,65 @@
+{
+  "left_toolbar": [
+    {
+      "name": "Pen",
+      "icon": "icons/toolpen.png",
+      "tools": [
+        {"name": "Pen", "icon": "icons/toolpen.png"}
+      ]
+    },
+    {
+      "name": "Eraser",
+      "icon": "icons/brush.png",
+      "tools": [
+        {"name": "Eraser", "icon": "icons/brush.png"}
+      ]
+    },
+    {
+      "name": "Bucket",
+      "icon": "icons/toolbucket.png",
+      "tools": [
+        {"name": "Bucket", "icon": "icons/toolbucket.png"}
+      ]
+    },
+    {
+      "name": "Picker",
+      "icon": "icons/toolpicker.png",
+      "tools": [
+        {"name": "Picker", "icon": "icons/toolpicker.png"}
+      ]
+    },
+    {
+      "name": "Move",
+      "icon": "icons/toolmove.png",
+      "tools": [
+        {"name": "Move", "icon": "icons/toolmove.png"}
+      ]
+    },
+    {
+      "name": "Rotate",
+      "icon": "icons/toolrotate.png",
+      "tools": [
+        {"name": "Rotate", "icon": "icons/toolrotate.png"}
+      ]
+    },
+    {
+      "name": "Shape Tools",
+      "icon": "icons/toolrect.png",
+      "tools": [
+        {"name": "Rectangle", "icon": "icons/toolrect.png"},
+        {"name": "Ellipse", "icon": "icons/toolellipse.png"},
+        {"name": "Line", "icon": "icons/toolline.png"}
+      ]
+    },
+    {
+      "name": "Selection Tools",
+      "icon": "icons/toolselectrect.png",
+      "tools": [
+        {"name": "Select Rectangle", "icon": "icons/toolselectrect.png"},
+        {"name": "Select Circle", "icon": "icons/toolselectcircle.png"},
+        {"name": "Select Lasso", "icon": "icons/toolselectlasso.png"},
+        {"name": "Select Color", "icon": "icons/toolselectcolor.png"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a portal/config/toolbar_tools.json file that lists the left toolbar tools, their icons, and shape/selection groupings
- update ToolBarBuilder to build grouped and standalone buttons from the layout config while keeping fallbacks for unconfigured tools
- refresh the toolbar builder test to exercise the config-driven layout and fallback handling

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68c8b4ee5e0c832187523de9ca8a4b94