### PR TITLE
Improve frame management notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ generation. Use the notes below to orient yourself quickly before making changes
 - `portal/core/`
   - `app.py` hosts the high-level `App` façade that the UI talks to.
   - `document.py`, `layer.py`, and `layer_manager.py` implement the document model.
+  - `frame.py` and `frame_manager.py` wrap layer stacks in animation-friendly frames. The active
+    frame is exposed on `Document.layer_manager` for backwards compatibility. Use
+    `Document.add_layer_manager_listener` when you need to rebind UI callbacks
+    after switching frames.
   - `document_controller.py` handles clipboard imports, palette quantisation, and smart cropping.
   - `drawing.py` contains flood fill, pixel-perfect brushes, symmetry helpers, and wrap-around logic.
   - `renderer.py` draws the canvas, background, grid, and tile preview mosaics.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,25 @@ QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py
 QT_QPA_PLATFORM=offscreen python -m pytest tests/test_drawing_tools.py
 QT_QPA_PLATFORM=offscreen python -m pytest tests/test_selection_tools.py
 ```
+
+## Working with Frames
+
+Pixel-Portal's document model now supports multiple frames inside a single
+project. Frames wrap their own layer stack and can be accessed through the
+`Document.frame_manager` helper. A few convenience methods are available on the
+document itself:
+
+- `Document.add_frame()` creates a fresh frame that mirrors the document size.
+- `Document.remove_frame(index)` removes a frame (while ensuring at least one
+  frame remains).
+- `Document.select_frame(index)` switches the active frame and therefore the
+  layer manager the UI interacts with.
+- `Document.render_current_frame()` composites the active frame into a single
+  `QImage`.
+- `Document.add_layer_manager_listener(callback)` registers a hook that fires
+  whenever the active frame changes. This keeps UI components wired to the
+  correct `LayerManager` as the selection moves between frames.
+
+The existing `Document.layer_manager` attribute now resolves to the layer
+manager belonging to the currently selected frame, so existing layer-centric
+tooling continues to operate without modification.

--- a/portal/core/frame.py
+++ b/portal/core/frame.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QImage, QPainter
+
+from portal.core.layer_manager import LayerManager
+
+
+class Frame:
+    """A single animation frame composed of a layer stack."""
+
+    def __init__(self, width: int, height: int, create_background: bool = True):
+        self.layer_manager = LayerManager(width, height, create_background=create_background)
+
+    @property
+    def width(self) -> int:
+        return self.layer_manager.width
+
+    @property
+    def height(self) -> int:
+        return self.layer_manager.height
+
+    def render(self) -> QImage:
+        """Composite the frame's visible layers into a single image."""
+        final_image = QImage(QSize(self.width, self.height), QImage.Format_ARGB32)
+        final_image.fill("transparent")
+
+        painter = QPainter(final_image)
+        for layer in self.layer_manager.layers:
+            if layer.visible:
+                painter.setOpacity(layer.opacity)
+                painter.drawImage(0, 0, layer.image)
+        painter.end()
+
+        return final_image
+
+    def clone(self) -> "Frame":
+        """Create a deep copy of the frame and its layers."""
+        cloned_frame = Frame(self.width, self.height, create_background=False)
+        cloned_frame.layer_manager = self.layer_manager.clone()
+        return cloned_frame

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -25,16 +25,15 @@ class DocumentService:
             app.config.set('General', 'last_directory', app.last_directory)
 
             if file_path.lower().endswith(('.tif', '.tiff')):
-                app.document = Document.load_tiff(file_path)
+                document = Document.load_tiff(file_path)
             else:
                 image = QImage(file_path)
-                if not image.isNull():
-                    app.document = Document(image.width(), image.height())
-                    app.document.layer_manager.layers[0].image = image
+                if image.isNull():
+                    return
+                document = Document(image.width(), image.height())
+                document.layer_manager.layers[0].image = image
 
-            app.document.layer_manager.layer_visibility_changed.connect(app.on_layer_visibility_changed)
-            app.document.layer_manager.layer_structure_changed.connect(app.on_layer_structure_changed)
-            app.document.layer_manager.command_generated.connect(app.handle_command)
+            app.attach_document(document)
             app.undo_manager.clear()
             app.is_dirty = False
             app.undo_stack_changed.emit()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -283,6 +283,7 @@ def mock_main_window(qapp):
     window.open_background_image_dialog = MagicMock()
     window.toggle_ai_panel = MagicMock()
     window.open_flip_dialog = MagicMock()
+    window.open_settings_dialog = MagicMock()
     return window
 
 def test_setup_actions(mock_main_window):

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -1,0 +1,90 @@
+from PySide6.QtGui import QColor
+
+from portal.core.document import Document
+
+
+def test_document_initializes_with_single_frame():
+    document = Document(4, 4)
+
+    assert len(document.frame_manager.frames) == 1
+    assert document.frame_manager.active_frame_index == 0
+    assert document.layer_manager is document.frame_manager.current_layer_manager
+
+
+def test_document_add_and_select_frames():
+    document = Document(4, 4)
+    first_manager = document.layer_manager
+
+    document.add_frame()
+
+    assert len(document.frame_manager.frames) == 2
+    assert document.frame_manager.active_frame_index == 1
+    assert document.layer_manager is document.frame_manager.frames[1].layer_manager
+
+    document.select_frame(0)
+    assert document.layer_manager is first_manager
+
+
+def test_render_current_frame_tracks_active_frame():
+    document = Document(2, 2)
+    document.layer_manager.active_layer.image.fill(QColor("red"))
+
+    red_pixel = document.render_current_frame().pixelColor(0, 0)
+    assert red_pixel == QColor("red")
+
+    document.add_frame()
+    document.layer_manager.active_layer.image.fill(QColor("blue"))
+
+    blue_pixel = document.render_current_frame().pixelColor(0, 0)
+    assert blue_pixel == QColor("blue")
+
+    document.select_frame(0)
+    red_again = document.render().pixelColor(0, 0)
+    assert red_again == QColor("red")
+
+
+def test_remove_frame_updates_active_index():
+    document = Document(2, 2)
+    document.add_frame()
+    document.select_frame(0)
+
+    document.remove_frame(0)
+
+    assert len(document.frame_manager.frames) == 1
+    assert document.frame_manager.active_frame_index == 0
+    assert document.layer_manager is document.frame_manager.current_layer_manager
+
+
+def test_layer_manager_listener_notified_on_frame_change():
+    document = Document(3, 3)
+    observed = []
+
+    document.add_layer_manager_listener(observed.append)
+    assert observed[-1] is document.layer_manager
+
+    document.add_frame()
+    assert observed[-1] is document.layer_manager
+
+    document.select_frame(0)
+    assert observed[-1] is document.layer_manager
+
+    document.remove_frame(1)
+    assert observed[-1] is document.layer_manager
+
+
+def test_clone_copies_frames_and_layers():
+    document = Document(2, 2)
+    document.layer_manager.add_layer("Foreground")
+    document.layer_manager.active_layer.image.fill(QColor("green"))
+    document.add_frame()
+    document.layer_manager.add_layer("Second Frame Layer")
+
+    clone = document.clone()
+
+    assert len(clone.frame_manager.frames) == len(document.frame_manager.frames)
+    assert clone.frame_manager.active_frame_index == document.frame_manager.active_frame_index
+
+    for original_frame, cloned_frame in zip(document.frame_manager.frames, clone.frame_manager.frames):
+        assert cloned_frame is not original_frame
+        assert cloned_frame.layer_manager is not original_frame.layer_manager
+        assert len(cloned_frame.layer_manager.layers) == len(original_frame.layer_manager.layers)

--- a/todo.txt
+++ b/todo.txt
@@ -3,3 +3,4 @@
 6. better status bar
 11. polygon create
 12. polygon select
+15. wire timeline UI to Document.add_layer_manager_listener for frame awareness


### PR DESCRIPTION
## Summary
- add layer-manager change listeners to `Document` and notify on frame operations
- rework `DocumentController`/`DocumentService` to swap documents via the listener so UI signals follow the active frame
- expand frame regression tests and documentation to cover listener behaviour

## Testing
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_frames.py
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_core.py

------
https://chatgpt.com/codex/tasks/task_e_68c98772a834832190c45b379aee441a