### PR TITLE
Add script to promote partially transparent pixels

### DIFF
--- a/portal/core/scripting.py
+++ b/portal/core/scripting.py
@@ -20,6 +20,12 @@ class ScriptingAPI:
             return layers[index]
         return None
 
+    def get_active_layer(self) -> Layer | None:
+        """Returns the currently active layer, if any."""
+        if self.app.document:
+            return self.app.document.layer_manager.active_layer
+        return None
+
     def create_layer(self, name):
         """Creates a new layer with the given name and returns it."""
         if self.app.document:

--- a/portal/ui/script_dialog.py
+++ b/portal/ui/script_dialog.py
@@ -1,4 +1,15 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QDialogButtonBox, QLineEdit, QSpinBox, QComboBox, QPushButton, QColorDialog
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QFormLayout,
+    QDialogButtonBox,
+    QLineEdit,
+    QSpinBox,
+    QComboBox,
+    QPushButton,
+    QColorDialog,
+    QCheckBox,
+)
 from PySide6.QtGui import QColor
 
 class ColorButton(QPushButton):
@@ -56,6 +67,12 @@ class ScriptDialog(QDialog):
                     widget.addItems(param['choices'])
                 if default is not None:
                     widget.setCurrentText(default)
+            elif param_type == 'checkbox':
+                widget = QCheckBox()
+                if default is not None:
+                    widget.setChecked(bool(default))
+                else:
+                    widget.setChecked(False)
 
             self.form_layout.addRow(label, widget)
             self.widgets[name] = (param_type, widget)
@@ -78,4 +95,6 @@ class ScriptDialog(QDialog):
                 values[name] = widget.color
             elif param_type == 'choice':
                 values[name] = widget.currentText()
+            elif param_type == 'checkbox':
+                values[name] = widget.isChecked()
         return values

--- a/portal/ui/script_dialog.py
+++ b/portal/ui/script_dialog.py
@@ -1,3 +1,4 @@
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog,
     QVBoxLayout,
@@ -9,6 +10,10 @@ from PySide6.QtWidgets import (
     QPushButton,
     QColorDialog,
     QCheckBox,
+    QWidget,
+    QSlider,
+    QHBoxLayout,
+    QLabel,
 )
 from PySide6.QtGui import QColor
 
@@ -33,6 +38,32 @@ class ColorButton(QPushButton):
         color = QColorDialog.getColor(self._color, self)
         if color.isValid():
             self.color = color
+
+class SliderWithLabel(QWidget):
+    """Slider widget that displays its current percentage value."""
+
+    def __init__(self, minimum, maximum, default, step=1):
+        super().__init__()
+        self.slider = QSlider(Qt.Horizontal)
+        self.slider.setRange(minimum, maximum)
+        self.slider.setSingleStep(step)
+        self.slider.setPageStep(step)
+        self.value_label = QLabel()
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.slider)
+        layout.addWidget(self.value_label)
+
+        self.slider.valueChanged.connect(self._update_label)
+        self.slider.setValue(default)
+        self._update_label(self.slider.value())
+
+    def _update_label(self, value):
+        self.value_label.setText(f"{value}%")
+
+    def value(self):
+        return self.slider.value()
 
 class ScriptDialog(QDialog):
     def __init__(self, params, parent=None):
@@ -73,6 +104,14 @@ class ScriptDialog(QDialog):
                     widget.setChecked(bool(default))
                 else:
                     widget.setChecked(False)
+            elif param_type == 'slider':
+                minimum = param.get('min', 0)
+                maximum = param.get('max', 100)
+                step = param.get('step', 1)
+                if default is None:
+                    default = minimum
+                default = max(minimum, min(maximum, default))
+                widget = SliderWithLabel(minimum, maximum, default, step)
 
             self.form_layout.addRow(label, widget)
             self.widgets[name] = (param_type, widget)
@@ -97,4 +136,6 @@ class ScriptDialog(QDialog):
                 values[name] = widget.currentText()
             elif param_type == 'checkbox':
                 values[name] = widget.isChecked()
+            elif param_type == 'slider':
+                values[name] = widget.value()
         return values

--- a/scripts/make_pixels_opaque.py
+++ b/scripts/make_pixels_opaque.py
@@ -1,0 +1,43 @@
+"""Script to promote partially transparent pixels to full opacity."""
+
+# Define the parameters for the script
+params = [
+    {
+        'name': 'include_fully_transparent',
+        'type': 'checkbox',
+        'label': 'Affect fully transparent pixels',
+        'default': False,
+    }
+]
+
+
+def main(api, values):
+    """Entry point for the script."""
+    include_all = values.get('include_fully_transparent', False)
+
+    active_layer = api.get_active_layer()
+    if active_layer is None:
+        api.show_message_box("Script Error", "No active layer is selected.")
+        return
+
+    def promote_pixels(image):
+        if not image.hasAlphaChannel():
+            return
+
+        width = image.width()
+        height = image.height()
+
+        for y in range(height):
+            for x in range(width):
+                color = image.pixelColor(x, y)
+                alpha = color.alpha()
+
+                if alpha == 255:
+                    continue
+                if alpha == 0 and not include_all:
+                    continue
+
+                color.setAlpha(255)
+                image.setPixelColor(x, y, color)
+
+    api.modify_layer(active_layer, promote_pixels)


### PR DESCRIPTION
## Summary
- add checkbox support to the scripting parameter dialog and expose the active layer through the scripting API
- introduce a script that promotes partially transparent pixels to full opacity with an option to affect fully transparent pixels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9ac84ae808321a32eba6cb4730ff0