### PR TITLE
Add pixel perfect outline script

### DIFF
--- a/portal/core/scripting.py
+++ b/portal/core/scripting.py
@@ -29,6 +29,12 @@ class ScriptingAPI:
             return self.app.document.layer_manager.active_layer
         return None
 
+    def get_active_layer(self):
+        """Returns the currently active layer."""
+        if self.app.document:
+            return self.app.document.layer_manager.active_layer
+        return None
+
     def modify_layer(self, layer, drawing_func):
         """Modifies a layer's image using a drawing function."""
         if layer:

--- a/portal/ui/script_dialog.py
+++ b/portal/ui/script_dialog.py
@@ -1,4 +1,15 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QDialogButtonBox, QLineEdit, QSpinBox, QComboBox, QPushButton, QColorDialog
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QFormLayout,
+    QDialogButtonBox,
+    QLineEdit,
+    QSpinBox,
+    QComboBox,
+    QPushButton,
+    QColorDialog,
+    QCheckBox,
+)
 from PySide6.QtGui import QColor
 
 class ColorButton(QPushButton):
@@ -56,6 +67,9 @@ class ScriptDialog(QDialog):
                     widget.addItems(param['choices'])
                 if default is not None:
                     widget.setCurrentText(default)
+            elif param_type == 'checkbox':
+                widget = QCheckBox()
+                widget.setChecked(bool(default))
 
             self.form_layout.addRow(label, widget)
             self.widgets[name] = (param_type, widget)
@@ -78,4 +92,6 @@ class ScriptDialog(QDialog):
                 values[name] = widget.color
             elif param_type == 'choice':
                 values[name] = widget.currentText()
+            elif param_type == 'checkbox':
+                values[name] = widget.isChecked()
         return values

--- a/scripts/pixel_perfect_outline.py
+++ b/scripts/pixel_perfect_outline.py
@@ -1,0 +1,143 @@
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+
+# Define the parameters for the script
+params = [
+    {
+        'name': 'outline_width',
+        'type': 'number',
+        'label': 'Outline Width',
+        'default': 1,
+        'min': 1,
+        'max': 16,
+    },
+    {
+        'name': 'outline_color',
+        'type': 'color',
+        'label': 'Outline Color',
+        'default': '#000000',
+    },
+    {
+        'name': 'remove_background',
+        'type': 'checkbox',
+        'label': 'Remove Background',
+        'default': False,
+    },
+]
+
+
+def _coerce_color(value):
+    if isinstance(value, QColor):
+        return QColor(value)
+    color = QColor(value)
+    if not color.isValid():
+        return QColor('black')
+    return color
+
+
+def _has_visible_pixels(image):
+    for y in range(image.height()):
+        for x in range(image.width()):
+            if image.pixelColor(x, y).alpha() > 0:
+                return True
+    return False
+
+
+def main(api, values):
+    get_active_layer = getattr(api, 'get_active_layer', None)
+    layer = get_active_layer() if callable(get_active_layer) else None
+    if layer is None:
+        layers = api.get_all_layers()
+        layer = layers[-1] if layers else None
+
+    if layer is None:
+        api.show_message_box('Script Error', 'No active layer is available.')
+        return
+
+    outline_width = values.get('outline_width', 1)
+    try:
+        outline_width = int(outline_width)
+    except (TypeError, ValueError):
+        outline_width = 1
+    outline_width = max(1, outline_width)
+
+    outline_color = _coerce_color(values.get('outline_color', QColor('black')))
+    remove_background = bool(values.get('remove_background', False))
+
+    if not _has_visible_pixels(layer.image):
+        api.show_message_box(
+            'Pixel Perfect Outline',
+            'The active layer does not contain any visible pixels to outline.',
+        )
+        return
+
+    neighbor_offsets = [
+        (-1, -1),
+        (-1, 0),
+        (-1, 1),
+        (0, -1),
+        (0, 1),
+        (1, -1),
+        (1, 0),
+        (1, 1),
+    ]
+
+    target_rgba = outline_color.rgba()
+
+    def draw_outline(image):
+        original = image.copy()
+        width = original.width()
+        height = original.height()
+
+        content_mask = set()
+        for y in range(height):
+            for x in range(width):
+                if original.pixelColor(x, y).alpha() > 0:
+                    content_mask.add((x, y))
+
+        if not content_mask:
+            return
+
+        existing_outline_pixels = set()
+        for (x, y) in content_mask:
+            color = original.pixelColor(x, y)
+            if color.rgba() != target_rgba:
+                continue
+            for dx, dy in neighbor_offsets:
+                nx = x + dx
+                ny = y + dy
+                if nx < 0 or ny < 0 or nx >= width or ny >= height:
+                    existing_outline_pixels.add((x, y))
+                    break
+                if (nx, ny) not in content_mask:
+                    existing_outline_pixels.add((x, y))
+                    break
+
+        core_pixels = content_mask.difference(existing_outline_pixels)
+        if not core_pixels:
+            core_pixels = content_mask
+
+        new_outline_pixels = set()
+        for (x, y) in core_pixels:
+            for dx in range(-outline_width, outline_width + 1):
+                for dy in range(-outline_width, outline_width + 1):
+                    if dx == 0 and dy == 0:
+                        continue
+                    if max(abs(dx), abs(dy)) > outline_width:
+                        continue
+                    nx = x + dx
+                    ny = y + dy
+                    if 0 <= nx < width and 0 <= ny < height:
+                        if (nx, ny) not in content_mask:
+                            new_outline_pixels.add((nx, ny))
+
+        if remove_background:
+            image.fill(Qt.transparent)
+
+        for (x, y) in new_outline_pixels:
+            image.setPixelColor(x, y, outline_color)
+
+        for (x, y) in existing_outline_pixels:
+            image.setPixelColor(x, y, outline_color)
+
+    api.modify_layer(layer, draw_outline)


### PR DESCRIPTION
## Summary
- expose the active layer through the scripting API and add checkbox support to the scripting dialog
- add a Pixel Perfect Outline script that can draw a configurable outline around the active layer and optionally strip the background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9ad6599408321ba8b84ade95bf1f1