### PR TITLE
Add undoable keyframe operations to timeline widget

### DIFF
--- a/portal/commands/timeline_commands.py
+++ b/portal/commands/timeline_commands.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from portal.core.command import Command
+from portal.core.document import Document
+
+
+class _KeyframeCommand(Command):
+    """Base helper that snapshots keyframe state for undo/redo."""
+
+    def __init__(self, document: Document):
+        self.document = document
+        self._previous_keys: list[int] | None = None
+
+    def _capture_before(self) -> None:
+        if self._previous_keys is None:
+            self._previous_keys = list(self.document.key_frames)
+
+    def undo(self) -> None:
+        if self._previous_keys is None:
+            return
+        self.document.set_key_frames(self._previous_keys)
+
+
+class AddKeyframeCommand(_KeyframeCommand):
+    """Add a keyframe at ``frame_index``."""
+
+    def __init__(self, document: Document, frame_index: int):
+        super().__init__(document)
+        self.frame_index = frame_index
+
+    def execute(self) -> None:
+        self._capture_before()
+        self.document.add_key_frame(self.frame_index)
+
+
+class RemoveKeyframeCommand(_KeyframeCommand):
+    """Remove a keyframe at ``frame_index`` if possible."""
+
+    def __init__(self, document: Document, frame_index: int):
+        super().__init__(document)
+        self.frame_index = frame_index
+
+    def execute(self) -> None:
+        self._capture_before()
+        self.document.remove_key_frame(self.frame_index)
+
+
+class DuplicateKeyframeCommand(_KeyframeCommand):
+    """Duplicate an existing keyframe to another frame index."""
+
+    def __init__(
+        self,
+        document: Document,
+        source_frame: Optional[int] = None,
+        target_frame: Optional[int] = None,
+    ) -> None:
+        super().__init__(document)
+        self.source_frame = source_frame
+        self.target_frame = target_frame
+        self.created_frame: Optional[int] = None
+
+    def execute(self) -> None:
+        self._capture_before()
+        target = self.target_frame if self.target_frame is not None else self.created_frame
+        result = self.document.duplicate_key_frame(self.source_frame, target)
+        if result is not None:
+            self.created_frame = result

--- a/portal/commands/timeline_commands.py
+++ b/portal/commands/timeline_commands.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from portal.core.command import Command
 from portal.core.document import Document
+from portal.core.frame_manager import FrameManager
 
 
 class _KeyframeCommand(Command):
@@ -11,16 +12,16 @@ class _KeyframeCommand(Command):
 
     def __init__(self, document: Document):
         self.document = document
-        self._previous_keys: list[int] | None = None
+        self._previous_state: FrameManager | None = None
 
     def _capture_before(self) -> None:
-        if self._previous_keys is None:
-            self._previous_keys = list(self.document.key_frames)
+        if self._previous_state is None:
+            self._previous_state = self.document.frame_manager.clone()
 
     def undo(self) -> None:
-        if self._previous_keys is None:
+        if self._previous_state is None:
             return
-        self.document.set_key_frames(self._previous_keys)
+        self.document.apply_frame_manager_snapshot(self._previous_state)
 
 
 class AddKeyframeCommand(_KeyframeCommand):

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from PySide6.QtCore import QObject, Signal, Slot
 import os
 
@@ -125,6 +127,20 @@ class App(QObject):
     @Slot()
     def redo(self):
         self.document_controller.redo()
+
+    def add_keyframe(self, frame_index: int) -> None:
+        self.document_controller.add_keyframe(frame_index)
+
+    def remove_keyframe(self, frame_index: int) -> None:
+        self.document_controller.remove_keyframe(frame_index)
+
+    def duplicate_keyframe(
+        self, source_frame: Optional[int] = None, target_frame: Optional[int] = None
+    ) -> Optional[int]:
+        return self.document_controller.duplicate_keyframe(source_frame, target_frame)
+
+    def select_frame(self, index: int) -> None:
+        self.document_controller.select_frame(index)
 
     @Slot()
     def select_all(self):

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 import io
 import json
 
@@ -81,6 +81,24 @@ class Document:
 
     def render_current_frame(self) -> QImage:
         return self.frame_manager.render_current_frame()
+
+    @property
+    def key_frames(self) -> list[int]:
+        return sorted(self.frame_manager.key_frames)
+
+    def set_key_frames(self, frames: Iterable[int]) -> bool:
+        return self.frame_manager.set_key_frames(frames)
+
+    def add_key_frame(self, frame: int) -> bool:
+        return self.frame_manager.add_key_frame(frame)
+
+    def remove_key_frame(self, frame: int) -> bool:
+        return self.frame_manager.remove_key_frame(frame)
+
+    def duplicate_key_frame(
+        self, source_frame: int | None = None, target_frame: int | None = None
+    ) -> int | None:
+        return self.frame_manager.duplicate_key_frame(source_frame, target_frame)
 
     @staticmethod
     def qimage_to_pil(qimage):

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -87,18 +87,36 @@ class Document:
         return sorted(self.frame_manager.key_frames)
 
     def set_key_frames(self, frames: Iterable[int]) -> bool:
-        return self.frame_manager.set_key_frames(frames)
+        changed = self.frame_manager.set_key_frames(frames)
+        if changed:
+            self._notify_layer_manager_changed()
+        return changed
 
     def add_key_frame(self, frame: int) -> bool:
-        return self.frame_manager.add_key_frame(frame)
+        changed = self.frame_manager.add_key_frame(frame)
+        if changed:
+            self._notify_layer_manager_changed()
+        return changed
 
     def remove_key_frame(self, frame: int) -> bool:
-        return self.frame_manager.remove_key_frame(frame)
+        changed = self.frame_manager.remove_key_frame(frame)
+        if changed:
+            self._notify_layer_manager_changed()
+        return changed
 
     def duplicate_key_frame(
         self, source_frame: int | None = None, target_frame: int | None = None
     ) -> int | None:
-        return self.frame_manager.duplicate_key_frame(source_frame, target_frame)
+        created = self.frame_manager.duplicate_key_frame(source_frame, target_frame)
+        if created is not None:
+            self._notify_layer_manager_changed()
+        return created
+
+    def apply_frame_manager_snapshot(self, snapshot: FrameManager) -> None:
+        self.frame_manager = snapshot.clone()
+        self.width = self.frame_manager.width
+        self.height = self.frame_manager.height
+        self._notify_layer_manager_changed()
 
     @staticmethod
     def qimage_to_pil(qimage):

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -76,6 +76,9 @@ class Document:
         self._notify_layer_manager_changed()
 
     def select_frame(self, index: int):
+        if index < 0:
+            index = 0
+        self.frame_manager.ensure_frame(index)
         self.frame_manager.select_frame(index)
         self._notify_layer_manager_changed()
 

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -128,9 +128,11 @@ class DocumentController(QObject):
         document = self.document
         if document is None:
             return
-        if frame_index in document.key_frames:
+        if frame_index < 0:
             return
-        if frame_index < 0 or frame_index >= len(document.frame_manager.frames):
+        frame_manager = document.frame_manager
+        frame_manager.ensure_frame(frame_index)
+        if frame_index in document.key_frames:
             return
         command = AddKeyframeCommand(document, frame_index)
         self.execute_command(command)
@@ -156,13 +158,11 @@ class DocumentController(QObject):
             return None
         if not document.key_frames:
             return None
-        frame_count = len(document.frame_manager.frames)
-        if frame_count <= 0:
+        frame_manager = document.frame_manager
+        if target_frame is not None and target_frame < 0:
             return None
-        if target_frame is not None and not (0 <= target_frame < frame_count):
-            return None
-        if target_frame is None and len(document.key_frames) >= frame_count:
-            return None
+        if target_frame is not None:
+            frame_manager.ensure_frame(target_frame)
 
         command = DuplicateKeyframeCommand(document, source_frame, target_frame)
         self.execute_command(command)
@@ -239,8 +239,9 @@ class DocumentController(QObject):
         if document is None:
             return
         frame_manager = document.frame_manager
-        if not (0 <= index < len(frame_manager.frames)):
+        if index < 0:
             return
+        frame_manager.ensure_frame(index)
         if frame_manager.active_frame_index == index:
             return
         document.select_frame(index)

--- a/portal/core/frame_manager.py
+++ b/portal/core/frame_manager.py
@@ -347,12 +347,21 @@ class FrameManager:
                 index = base_manager.layers.index(layer)
             except ValueError:
                 index = len(base_manager.layers)
+        target_active_index = max(0, index if index is not None else 0)
         for frame in self.frames:
             manager = frame.layer_manager
-            if self._find_layer(manager, layer.uid) is not None:
-                continue
-            clone = layer.clone()
-            manager.layers.insert(index, clone)
+            insertion_index = index if index is not None else len(manager.layers)
+            if insertion_index < 0:
+                insertion_index = 0
+            if insertion_index > len(manager.layers):
+                insertion_index = len(manager.layers)
+            if self._find_layer(manager, layer.uid) is None:
+                clone = layer.clone()
+                manager.layers.insert(insertion_index, clone)
+            if manager.layers:
+                manager.active_layer_index = min(
+                    target_active_index, len(manager.layers) - 1
+                )
         keys = {0} if key_frames is None else {max(0, int(value)) for value in key_frames}
         if not keys:
             keys = {0}

--- a/portal/core/frame_manager.py
+++ b/portal/core/frame_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Iterable, List, Optional, Set
 
 from PySide6.QtGui import QImage
 
@@ -19,6 +19,7 @@ class FrameManager:
         self.height = height
         self.frames: List[Frame] = [Frame(width, height) for _ in range(frame_count)]
         self.active_frame_index = 0 if self.frames else -1
+        self.key_frames: Set[int] = {0} if self.frames else set()
 
     @property
     def current_frame(self) -> Optional[Frame]:
@@ -44,6 +45,8 @@ class FrameManager:
             frame.layer_manager.height = self.height
         self.frames.append(frame)
         self.active_frame_index = len(self.frames) - 1
+        if not self.key_frames:
+            self.key_frames.add(self.active_frame_index)
         return frame
 
     def remove_frame(self, index: int) -> None:
@@ -61,6 +64,19 @@ class FrameManager:
         elif self.active_frame_index > index:
             self.active_frame_index -= 1
 
+        if index in self.key_frames:
+            self.key_frames.remove(index)
+        remaining_keys = {
+            frame_index if frame_index < index else frame_index - 1
+            for frame_index in self.key_frames
+            if frame_index != index
+        }
+        self.key_frames = remaining_keys
+        if not self.key_frames and self.frames:
+            fallback = min(self.active_frame_index, len(self.frames) - 1)
+            fallback = max(0, fallback)
+            self.key_frames.add(fallback)
+
     def select_frame(self, index: int) -> None:
         if not (0 <= index < len(self.frames)):
             raise IndexError("Frame index out of range.")
@@ -76,7 +92,81 @@ class FrameManager:
         cloned_manager = FrameManager(self.width, self.height, frame_count=0)
         cloned_manager.frames = [frame.clone() for frame in self.frames]
         cloned_manager.active_frame_index = self.active_frame_index
+        cloned_manager.key_frames = set(self.key_frames)
         return cloned_manager
+
+    # ------------------------------------------------------------------
+    # Keyframe helpers
+    # ------------------------------------------------------------------
+    def set_key_frames(self, frames: Iterable[int]) -> bool:
+        """Replace the tracked keyframes with ``frames``.
+
+        Returns ``True`` if the set changed.
+        """
+
+        normalized = {
+            frame for frame in (int(value) for value in frames)
+            if 0 <= frame < len(self.frames)
+        }
+        if not normalized and self.frames:
+            fallback = min(self.active_frame_index, len(self.frames) - 1)
+            normalized = {max(0, fallback)}
+        if normalized == self.key_frames:
+            return False
+        self.key_frames = normalized
+        return True
+
+    def add_key_frame(self, index: int) -> bool:
+        if not (0 <= index < len(self.frames)):
+            return False
+        if index in self.key_frames:
+            return False
+        self.key_frames.add(index)
+        return True
+
+    def remove_key_frame(self, index: int) -> bool:
+        if not (0 <= index < len(self.frames)):
+            return False
+        if index not in self.key_frames:
+            return False
+        if len(self.key_frames) == 1:
+            return False
+        self.key_frames.remove(index)
+        if not self.key_frames and self.frames:
+            fallback = min(self.active_frame_index, len(self.frames) - 1)
+            self.key_frames.add(max(0, fallback))
+        return True
+
+    def duplicate_key_frame(
+        self, source_index: Optional[int] = None, target_index: Optional[int] = None
+    ) -> Optional[int]:
+        if not self.frames:
+            return None
+
+        if source_index is None:
+            if self.key_frames:
+                source_index = max(self.key_frames)
+            else:
+                source_index = min(self.active_frame_index, len(self.frames) - 1)
+        elif source_index not in self.key_frames:
+            return None
+
+        if source_index is None or not (0 <= source_index < len(self.frames)):
+            return None
+
+        if target_index is None:
+            candidate = source_index + 1
+            while candidate < len(self.frames) and candidate in self.key_frames:
+                candidate += 1
+            target_index = candidate
+
+        if target_index is None or not (0 <= target_index < len(self.frames)):
+            return None
+        if target_index in self.key_frames:
+            return None
+
+        self.key_frames.add(target_index)
+        return target_index
 
 
 def resolve_active_layer_manager(document) -> LayerManager | None:

--- a/portal/core/frame_manager.py
+++ b/portal/core/frame_manager.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from bisect import bisect_right
-from typing import Iterable, List, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 from PySide6.QtGui import QImage
 
 from portal.core.frame import Frame
+from portal.core.layer import Layer
 from portal.core.layer_manager import LayerManager
 
 
@@ -20,8 +21,100 @@ class FrameManager:
         self.height = height
         self.frames: List[Frame] = [Frame(width, height) for _ in range(frame_count)]
         self.active_frame_index = 0 if self.frames else -1
-        self.key_frames: Set[int] = {0} if self.frames else set()
+        self.frame_markers: Set[int] = {0} if self.frames else set()
+        self.layer_keys: Dict[int, Set[int]] = {}
+        self._initialize_layer_keys()
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _initialize_layer_keys(self) -> None:
+        if not self.frames:
+            return
+        base_manager = self.frames[0].layer_manager
+        for frame in self.frames[1:]:
+            manager = frame.layer_manager
+            manager.layers = [layer.clone() for layer in base_manager.layers]
+            if manager.active_layer_index >= len(manager.layers):
+                manager.active_layer_index = len(manager.layers) - 1
+        for layer in base_manager.layers:
+            self.layer_keys.setdefault(layer.uid, {0})
+        if not self.frame_markers and self.frames:
+            self.frame_markers = {0}
+
+    def _refresh_frame_markers(self) -> None:
+        markers: Set[int] = set()
+        for frames in self.layer_keys.values():
+            markers.update(frames)
+        if markers:
+            self.frame_markers = markers
+        elif self.frames:
+            self.frame_markers = {0}
+        else:
+            self.frame_markers = set()
+
+    @staticmethod
+    def _find_layer_index(layer_manager: LayerManager, layer_uid: int) -> Optional[int]:
+        for index, layer in enumerate(layer_manager.layers):
+            if getattr(layer, "uid", None) == layer_uid:
+                return index
+        return None
+
+    @staticmethod
+    def _find_layer(layer_manager: LayerManager, layer_uid: int) -> Optional[Layer]:
+        index = FrameManager._find_layer_index(layer_manager, layer_uid)
+        if index is None:
+            return None
+        return layer_manager.layers[index]
+
+    def _clone_layer_state(
+        self, layer_uid: int, source_frame_index: int, target_frame_index: int
+    ) -> None:
+        if not (0 <= source_frame_index < len(self.frames)):
+            return
+        if not (0 <= target_frame_index < len(self.frames)):
+            return
+        source_manager = self.frames[source_frame_index].layer_manager
+        target_manager = self.frames[target_frame_index].layer_manager
+        source_layer = self._find_layer(source_manager, layer_uid)
+        if source_layer is None:
+            return
+        target_layer = self._find_layer(target_manager, layer_uid)
+        if target_layer is None:
+            index = self._find_layer_index(source_manager, layer_uid)
+            if index is None:
+                return
+            clone = source_layer.clone()
+            target_manager.layers.insert(index, clone)
+            target_layer = clone
+        if target_layer is source_layer:
+            return
+        target_layer.apply_key_state_from(source_layer)
+
+    def _copy_layer_between_layers(
+        self, source_uid: int, target_uid: int, frame_index: int
+    ) -> None:
+        if not (0 <= frame_index < len(self.frames)):
+            return
+        manager = self.frames[frame_index].layer_manager
+        source_layer = self._find_layer(manager, source_uid)
+        target_layer = self._find_layer(manager, target_uid)
+        if source_layer is None or target_layer is None or source_layer is target_layer:
+            return
+        target_layer.apply_key_state_from(source_layer)
+
+    @staticmethod
+    def _resolve_layer_key_from_set(keys: List[int], frame_index: int) -> Optional[int]:
+        if not keys:
+            return None
+        position = bisect_right(keys, frame_index)
+        if position:
+            return keys[position - 1]
+        return keys[0]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     @property
     def current_frame(self) -> Optional[Frame]:
         key_index = self.resolve_key_frame_index(self.active_frame_index)
@@ -51,8 +144,9 @@ class FrameManager:
         if not self.frames:
             self.frames.append(Frame(self.width, self.height))
             self.active_frame_index = 0
-            if not self.key_frames:
-                self.key_frames = {0}
+            if not self.frame_markers:
+                self.frame_markers = {0}
+            self._initialize_layer_keys()
 
         while len(self.frames) <= index:
             source_index = self.resolve_key_frame_index(len(self.frames))
@@ -69,8 +163,8 @@ class FrameManager:
             frame.layer_manager.height = self.height
         self.frames.append(frame)
         self.active_frame_index = len(self.frames) - 1
-        if not self.key_frames:
-            self.key_frames.add(self.active_frame_index)
+        if not self.frame_markers:
+            self.frame_markers.add(self.active_frame_index)
         return frame
 
     def remove_frame(self, index: int) -> None:
@@ -88,22 +182,25 @@ class FrameManager:
         elif self.active_frame_index > index:
             self.active_frame_index -= 1
 
-        if index in self.key_frames:
-            self.key_frames.remove(index)
-        remaining_keys = {
-            frame_index if frame_index < index else frame_index - 1
-            for frame_index in self.key_frames
-            if frame_index != index
-        }
-        self.key_frames = remaining_keys
-        if not self.key_frames and self.frames:
-            fallback = min(self.active_frame_index, len(self.frames) - 1)
-            fallback = max(0, fallback)
-            self.key_frames.add(fallback)
+        updated_keys: Dict[int, Set[int]] = {}
+        for layer_uid, frames in self.layer_keys.items():
+            shifted: Set[int] = set()
+            for frame_index in frames:
+                if frame_index == index:
+                    continue
+                if frame_index > index:
+                    shifted.add(frame_index - 1)
+                else:
+                    shifted.add(frame_index)
+            if not shifted and self.frames:
+                shifted = {0}
+            updated_keys[layer_uid] = shifted
+        self.layer_keys = updated_keys
+        self._refresh_frame_markers()
 
         resolved = self.resolve_key_frame_index(self.active_frame_index)
-        if resolved is None and self.key_frames:
-            self.active_frame_index = min(self.key_frames)
+        if resolved is None and self.frame_markers:
+            self.active_frame_index = min(self.frame_markers)
 
     def select_frame(self, index: int) -> None:
         if not (0 <= index < len(self.frames)):
@@ -120,18 +217,24 @@ class FrameManager:
         cloned_manager = FrameManager(self.width, self.height, frame_count=0)
         cloned_manager.frames = [frame.clone() for frame in self.frames]
         cloned_manager.active_frame_index = self.active_frame_index
-        cloned_manager.key_frames = set(self.key_frames)
+        cloned_manager.frame_markers = set(self.frame_markers)
+        cloned_manager.layer_keys = {
+            layer_uid: set(frames) for layer_uid, frames in self.layer_keys.items()
+        }
         return cloned_manager
 
     # ------------------------------------------------------------------
     # Keyframe helpers
     # ------------------------------------------------------------------
-    def set_key_frames(self, frames: Iterable[int]) -> bool:
-        """Replace the tracked keyframes with ``frames``.
+    def layer_key_frames(self, layer_uid: int) -> List[int]:
+        keys = self.layer_keys.get(layer_uid)
+        if not keys:
+            return [0]
+        return sorted(keys)
 
-        Returns ``True`` if the set changed.
-        """
-
+    def set_layer_key_frames(self, layer_uid: int, frames: Iterable[int]) -> bool:
+        if layer_uid not in self.layer_keys:
+            return False
         normalized: Set[int] = set()
         for value in frames:
             try:
@@ -144,107 +247,153 @@ class FrameManager:
             if frame < len(self.frames):
                 normalized.add(frame)
         if not normalized and self.frames:
-            fallback = min(self.active_frame_index, len(self.frames) - 1)
-            normalized = {max(0, fallback)}
-        if normalized == self.key_frames:
+            normalized = {0}
+        existing = self.layer_keys.get(layer_uid, {0})
+        if normalized == existing:
             return False
 
-        previous_keys = sorted(self.key_frames)
-        self.key_frames = normalized
-
-        # Ensure frames corresponding to the new key set contain data by
-        # cloning from their nearest predecessors in the previous state.
-        for key in sorted(self.key_frames):
-            if key >= len(self.frames) or key in previous_keys:
+        previous_keys = sorted(existing)
+        self.layer_keys[layer_uid] = normalized
+        for key in sorted(normalized):
+            if key in previous_keys:
                 continue
-            source_index: Optional[int] = None
-            if previous_keys:
-                position = bisect_right(previous_keys, key)
-                if position:
-                    source_index = previous_keys[position - 1]
-                else:
-                    source_index = previous_keys[0]
-            else:
-                source_index = key
-            if source_index is None:
-                continue
-            if 0 <= source_index < len(self.frames):
-                self.frames[key] = self.frames[source_index].clone()
+            fallback = self._resolve_layer_key_from_set(previous_keys, key)
+            if fallback is None:
+                fallback = key
+            self._clone_layer_state(layer_uid, fallback, key)
+        self._refresh_frame_markers()
         return True
 
-    def add_key_frame(self, index: int) -> bool:
+    def add_layer_key(self, layer_uid: int, index: int) -> bool:
         if index < 0:
             return False
         self.ensure_frame(index)
         if not (0 <= index < len(self.frames)):
             return False
-        if index in self.key_frames:
+        keys = self.layer_keys.setdefault(layer_uid, {0})
+        if index in keys:
             return False
-        source_index = self.resolve_key_frame_index(index)
+        source_index = self.resolve_layer_key_frame_index(layer_uid, index)
         if source_index is None:
             source_index = 0
-        self.frames[index] = self.frames[source_index].clone()
-        self.key_frames.add(index)
+        self._clone_layer_state(layer_uid, source_index, index)
+        keys.add(index)
+        self._refresh_frame_markers()
         return True
 
-    def remove_key_frame(self, index: int) -> bool:
-        if not (0 <= index < len(self.frames)):
+    def remove_layer_key(self, layer_uid: int, index: int) -> bool:
+        keys = self.layer_keys.get(layer_uid)
+        if keys is None or index not in keys:
             return False
-        if index not in self.key_frames:
+        if len(keys) == 1 or index == 0:
             return False
-        if len(self.key_frames) == 1:
-            return False
-        self.key_frames.remove(index)
-        if not self.key_frames and self.frames:
-            fallback = min(self.active_frame_index, len(self.frames) - 1)
-            self.key_frames.add(max(0, fallback))
-        fallback_index = self.resolve_key_frame_index(index)
-        if fallback_index is None and self.key_frames:
-            fallback_index = min(self.key_frames)
-        if fallback_index is not None and 0 <= fallback_index < len(self.frames):
-            self.frames[index] = self.frames[fallback_index].clone()
+        remaining = sorted(frame for frame in keys if frame != index)
+        fallback = self._resolve_layer_key_from_set(remaining, index)
+        keys.remove(index)
+        if fallback is not None:
+            self._clone_layer_state(layer_uid, fallback, index)
+        self._refresh_frame_markers()
         return True
 
-    def duplicate_key_frame(
-        self, source_index: Optional[int] = None, target_index: Optional[int] = None
+    def duplicate_layer_key(
+        self,
+        layer_uid: int,
+        source_index: Optional[int] = None,
+        target_index: Optional[int] = None,
     ) -> Optional[int]:
-        if not self.frames:
+        keys = self.layer_keys.get(layer_uid)
+        if not keys:
             return None
-
         if source_index is None:
-            if self.key_frames:
-                source_index = max(self.key_frames)
-            else:
-                source_index = min(self.active_frame_index, len(self.frames) - 1)
-        elif source_index not in self.key_frames:
+            source_index = max(keys)
+        elif source_index not in keys:
             return None
-
-        if source_index is None or not (0 <= source_index < len(self.frames)):
+        if source_index is None:
             return None
-
         if target_index is None:
             candidate = source_index + 1
-            while candidate < len(self.frames) and candidate in self.key_frames:
+            while candidate in keys:
                 candidate += 1
             target_index = candidate
-
         if target_index is None or target_index < 0:
             return None
         self.ensure_frame(target_index)
         if not (0 <= target_index < len(self.frames)):
             return None
-        if target_index in self.key_frames:
+        if target_index in keys:
             return None
-
-        self.frames[target_index] = self.frames[source_index].clone()
-        self.key_frames.add(target_index)
+        self._clone_layer_state(layer_uid, source_index, target_index)
+        keys.add(target_index)
+        self._refresh_frame_markers()
         return target_index
+
+    def register_new_layer(
+        self,
+        layer: Layer,
+        index: Optional[int] = None,
+        *,
+        key_frames: Optional[Iterable[int]] = None,
+    ) -> None:
+        if not self.frames:
+            self.frames.append(Frame(self.width, self.height))
+            self.active_frame_index = 0
+            self._initialize_layer_keys()
+        base_frame_index = self.resolve_key_frame_index(self.active_frame_index)
+        if base_frame_index is None:
+            base_frame_index = 0
+        base_manager = self.frames[base_frame_index].layer_manager
+        if index is None:
+            try:
+                index = base_manager.layers.index(layer)
+            except ValueError:
+                index = len(base_manager.layers)
+        for frame in self.frames:
+            manager = frame.layer_manager
+            if self._find_layer(manager, layer.uid) is not None:
+                continue
+            clone = layer.clone()
+            manager.layers.insert(index, clone)
+        keys = {0} if key_frames is None else {max(0, int(value)) for value in key_frames}
+        if not keys:
+            keys = {0}
+        self.layer_keys[layer.uid] = keys
+        for key in sorted(keys):
+            self.ensure_frame(key)
+            self._clone_layer_state(layer.uid, base_frame_index, key)
+        self._refresh_frame_markers()
+
+    def unregister_layer(self, layer_uid: int) -> None:
+        for frame in self.frames:
+            manager = frame.layer_manager
+            index = self._find_layer_index(manager, layer_uid)
+            if index is None:
+                continue
+            del manager.layers[index]
+            if manager.active_layer_index >= len(manager.layers):
+                manager.active_layer_index = max(0, len(manager.layers) - 1)
+        self.layer_keys.pop(layer_uid, None)
+        self._refresh_frame_markers()
+
+    def duplicate_layer_keys(self, source_uid: int, new_layer: Layer) -> None:
+        manager = self.current_layer_manager
+        if manager is None:
+            return
+        try:
+            index = manager.layers.index(new_layer)
+        except ValueError:
+            index = len(manager.layers) - 1
+        source_keys = self.layer_keys.get(source_uid, {0})
+        self.register_new_layer(new_layer, index=index, key_frames=source_keys)
+        for frame_index in source_keys:
+            self.ensure_frame(frame_index)
+            self._copy_layer_between_layers(source_uid, new_layer.uid, frame_index)
+        self._refresh_frame_markers()
 
     # ------------------------------------------------------------------
     # Resolution helpers
     # ------------------------------------------------------------------
     def resolve_key_frame_index(self, frame_index: Optional[int] = None) -> Optional[int]:
-        if not self.frames or not self.key_frames:
+        if not self.frames or not self.frame_markers:
             return None
         if frame_index is None:
             frame_index = self.active_frame_index
@@ -253,7 +402,25 @@ class FrameManager:
         if frame_index >= len(self.frames):
             frame_index = len(self.frames) - 1
 
-        sorted_keys = sorted(self.key_frames)
+        sorted_keys = sorted(self.frame_markers)
+        position = bisect_right(sorted_keys, frame_index)
+        if position:
+            return sorted_keys[position - 1]
+        return sorted_keys[0]
+
+    def resolve_layer_key_frame_index(
+        self, layer_uid: int, frame_index: Optional[int] = None
+    ) -> Optional[int]:
+        keys = self.layer_keys.get(layer_uid)
+        if not keys:
+            return None
+        if frame_index is None:
+            frame_index = self.active_frame_index
+        if frame_index < 0:
+            frame_index = 0
+        if frame_index >= len(self.frames):
+            frame_index = len(self.frames) - 1
+        sorted_keys = sorted(keys)
         position = bisect_right(sorted_keys, frame_index)
         if position:
             return sorted_keys[position - 1]

--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -43,7 +43,6 @@ class AnimationTimelineWidget(QWidget):
         self._tick_height = 36
         self._preferred_frame_spacing = 16.0
         self._is_dragging = False
-        self._max_allowed_frame = 0
 
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.setMinimumHeight(100)
@@ -59,14 +58,13 @@ class AnimationTimelineWidget(QWidget):
     def total_frames(self) -> int:
         """Return the highest frame index currently represented."""
 
-        return self._max_allowed_frame
+        highest_key = max(self._keys) if self._keys else 0
+        return max(self._base_total_frames, highest_key)
 
     def set_total_frames(self, frame_count: int) -> None:
         """Define the minimum highest frame index displayed by the timeline."""
 
         frame_count = max(0, int(frame_count))
-        highest_key = max(self._keys) if self._keys else 0
-        self._max_allowed_frame = max(frame_count, highest_key)
         if frame_count == self._base_total_frames:
             return
         self._base_total_frames = frame_count
@@ -132,8 +130,6 @@ class AnimationTimelineWidget(QWidget):
                 new_frame += 1
         else:
             new_frame = max(0, int(target_frame))
-        if new_frame > self._max_allowed_frame:
-            return
         if new_frame in self._keys:
             return
         self.add_key(new_frame)
@@ -241,21 +237,15 @@ class AnimationTimelineWidget(QWidget):
         frame = self._frame_at_point(event)
         menu = QMenu(self)
 
-        is_valid_frame = 0 <= frame <= self._max_allowed_frame
-
         add_action = menu.addAction(f"Add Key @ Frame {frame}")
-        add_action.setEnabled(is_valid_frame and frame not in self._keys)
+        add_action.setEnabled(frame not in self._keys)
 
         remove_action = menu.addAction(f"Remove Key @ Frame {frame}")
-        remove_action.setEnabled(
-            is_valid_frame and frame in self._keys and len(self._keys) > 1
-        )
+        remove_action.setEnabled(frame in self._keys and len(self._keys) > 1)
 
         menu.addSeparator()
         duplicate_action = menu.addAction(f"Duplicate Last Key @ Frame {frame}")
-        duplicate_action.setEnabled(
-            is_valid_frame and bool(self._keys) and frame not in self._keys
-        )
+        duplicate_action.setEnabled(bool(self._keys) and frame not in self._keys)
 
         chosen = menu.exec(event.globalPos())
         if chosen == add_action:
@@ -277,8 +267,7 @@ class AnimationTimelineWidget(QWidget):
         if layout.spacing <= 0:
             return 0
         frame = round((x - self._margin) / layout.spacing)
-        max_frame = min(layout.max_frame, self._max_allowed_frame)
-        frame = max(0, min(frame, max_frame))
+        frame = max(0, min(frame, layout.max_frame))
         return frame
 
     def _calculate_layout(self) -> _TimelineLayout:

--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -211,7 +211,7 @@ class LayerManagerWidget(QWidget):
                 self.app.execute_command(command)
         else:
             from portal.core.command import RemoveLayerCommand
-            command = RemoveLayerCommand(layer_manager, actual_index)
+            command = RemoveLayerCommand(self.app.document, actual_index)
             self.app.execute_command(command)
 
     def move_layer_up(self):
@@ -246,7 +246,7 @@ class LayerManagerWidget(QWidget):
     def duplicate_layer_from_menu(self, index_in_list):
         actual_index = len(self.app.document.layer_manager.layers) - 1 - index_in_list
         from portal.core.command import DuplicateLayerCommand
-        command = DuplicateLayerCommand(self.app.document.layer_manager, actual_index)
+        command = DuplicateLayerCommand(self.app.document, actual_index)
         self.app.execute_command(command)
 
     def remove_background_from_menu(self, index_in_list):

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -175,6 +175,7 @@ class MainWindow(QMainWindow):
         # Layer Manager Panel
         self.layer_manager_widget = LayerManagerWidget(self.app, self.canvas)
         self.layer_manager_widget.layer_changed.connect(self.canvas.update)
+        self.layer_manager_widget.layer_changed.connect(self.sync_timeline_from_document)
         self.layer_manager_dock = QDockWidget("Layers", self)
         self.layer_manager_dock.setWidget(self.layer_manager_widget)
         self.addDockWidget(Qt.RightDockWidgetArea, self.layer_manager_dock)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -640,7 +640,7 @@ def test_duplicate_layer_command(document):
     initial_layer_count = len(layer_manager.layers)
     layer_to_duplicate_index = layer_manager.active_layer_index
 
-    command = DuplicateLayerCommand(layer_manager, layer_to_duplicate_index)
+    command = DuplicateLayerCommand(document, layer_to_duplicate_index)
     command.execute()
 
     assert len(layer_manager.layers) == initial_layer_count + 1
@@ -648,6 +648,7 @@ def test_duplicate_layer_command(document):
     duplicated_layer = layer_manager.layers[layer_to_duplicate_index + 1]
     assert duplicated_layer.name == f"{original_layer.name} copy"
     assert duplicated_layer.image.constBits() == original_layer.image.constBits()
+    assert document.key_frames_for_layer(duplicated_layer) == document.key_frames_for_layer(original_layer)
 
     command.undo()
 
@@ -676,10 +677,14 @@ def test_remove_layer_command(document):
     """Test that the RemoveLayerCommand removes the layer and that undo restores it."""
     layer_manager = document.layer_manager
     layer_manager.add_layer("Layer 2")
+    document.register_layer(
+        layer_manager.active_layer,
+        layer_manager.active_layer_index,
+    )
     initial_layer_count = len(layer_manager.layers)
     layer_to_remove_index = 1
 
-    command = RemoveLayerCommand(layer_manager, layer_to_remove_index)
+    command = RemoveLayerCommand(document, layer_to_remove_index)
     command.execute()
 
     assert len(layer_manager.layers) == initial_layer_count - 1
@@ -694,7 +699,15 @@ def test_move_layer_command(document):
     """Test that the MoveLayerCommand moves the layer and that undo moves it back."""
     layer_manager = document.layer_manager
     layer_manager.add_layer("Layer 2")
+    document.register_layer(
+        layer_manager.active_layer,
+        layer_manager.active_layer_index,
+    )
     layer_manager.add_layer("Layer 3")
+    document.register_layer(
+        layer_manager.active_layer,
+        layer_manager.active_layer_index,
+    )
 
     original_layers = list(layer_manager.layers)
     from_index = 0

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -25,6 +25,10 @@ def document():
     """Returns a Document with two layers."""
     doc = Document(100, 100)
     doc.layer_manager.add_layer("Layer 2")
+    doc.register_layer(
+        doc.layer_manager.active_layer,
+        doc.layer_manager.active_layer_index,
+    )
     # Fill layers with some content for rendering tests
     layer1 = doc.layer_manager.layers[0]
     layer2 = doc.layer_manager.layers[1]
@@ -157,6 +161,10 @@ def test_crop_expands_document_when_selection_is_larger():
     assert base_layer.image.pixelColor(5, 3) == QColor("red")
 
     doc.layer_manager.add_layer("Post Crop")
+    doc.register_layer(
+        doc.layer_manager.active_layer,
+        doc.layer_manager.active_layer_index,
+    )
     new_layer = doc.layer_manager.active_layer
     assert new_layer.image.width() == selection_rect.width()
     assert new_layer.image.height() == selection_rect.height()
@@ -496,10 +504,18 @@ def test_eraser_preview_layer_order(qtbot):
 
     # Layer 2 (middle): Green
     document.layer_manager.add_layer("Middle Layer")
+    document.register_layer(
+        document.layer_manager.active_layer,
+        document.layer_manager.active_layer_index,
+    )
     document.layer_manager.active_layer.image.fill(QColor("green"))
 
     # Layer 3 (top): Blue
     document.layer_manager.add_layer("Top Layer")
+    document.register_layer(
+        document.layer_manager.active_layer,
+        document.layer_manager.active_layer_index,
+    )
     document.layer_manager.active_layer.image.fill(QColor("blue"))
 
     # Set active layer to the middle layer

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -148,9 +148,17 @@ def test_layer_manager_listener_notified_on_frame_change():
 def test_clone_copies_frames_and_layers():
     document = Document(2, 2)
     document.layer_manager.add_layer("Foreground")
+    document.register_layer(
+        document.layer_manager.active_layer,
+        document.layer_manager.active_layer_index,
+    )
     document.layer_manager.active_layer.image.fill(QColor("green"))
     document.add_frame()
     document.layer_manager.add_layer("Second Frame Layer")
+    document.register_layer(
+        document.layer_manager.active_layer,
+        document.layer_manager.active_layer_index,
+    )
 
     clone = document.clone()
 
@@ -173,6 +181,24 @@ def test_document_key_frames_follow_frame_removal():
     document.remove_frame(0)
 
     assert document.key_frames == [0]
+
+
+def test_new_layer_starts_with_base_key_only():
+    document = Document(4, 4)
+    base_layer = document.layer_manager.active_layer
+    document.add_key_frame(3)
+
+    document.layer_manager.add_layer("Second")
+    document.register_layer(
+        document.layer_manager.active_layer,
+        document.layer_manager.active_layer_index,
+    )
+    new_layer = document.layer_manager.active_layer
+
+    assert document.key_frames_for_layer(new_layer) == [0]
+
+    document.layer_manager.select_layer(0)
+    assert document.key_frames_for_layer(base_layer) == [0, 3]
 
 
 def test_add_keyframe_command_supports_undo_redo():

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -201,6 +201,32 @@ def test_new_layer_starts_with_base_key_only():
     assert document.key_frames_for_layer(base_layer) == [0, 3]
 
 
+def test_new_layer_added_on_future_frame_has_single_key_and_selection():
+    document = Document(4, 4)
+    document.add_key_frame(8)
+    document.select_frame(8)
+
+    document.layer_manager.add_layer("Future Layer")
+    new_layer = document.layer_manager.active_layer
+    insertion_index = document.layer_manager.active_layer_index
+
+    document.register_layer(new_layer, insertion_index)
+
+    assert document.key_frames_for_layer(new_layer) == [0]
+    assert document.key_frames == [0]
+
+    target_index = document.layer_manager.active_layer_index
+    for frame in document.frame_manager.frames:
+        manager = frame.layer_manager
+        assert manager.layers[target_index].uid == new_layer.uid
+        assert manager.active_layer_index == target_index
+
+    document.select_frame(0)
+
+    assert document.layer_manager.active_layer.uid == new_layer.uid
+    assert document.key_frames == [0]
+
+
 def test_add_keyframe_command_supports_undo_redo():
     document = Document(4, 4)
     document.layer_manager.active_layer.image.fill(QColor("red"))


### PR DESCRIPTION
## Summary
- track keyframes inside the frame manager/document and expose helpers for manipulating them
- add dedicated timeline keyframe commands so undo/redo restores the key set correctly
- wire the timeline widget and main window to the new commands and expand frame tests to cover keyframes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9d60554a08321b5cd5491d7f481c2