### PR TITLE
Add animation playback controls and player

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pixel-Portal is a lightweight, cross-platform image editor built with Python and
 - **Drawing Tools**: A variety of tools for drawing and painting, including Pen, Bucket, Ellipse, Line, and Rectangle.
 - **Layer Management**: Full support for layers, allowing for complex image compositions. You can add, remove, reorder, and merge layers.
 - **Frame-aware Rendering**: Canvas compositing and drawing tools operate on the active frame so animation edits stay isolated.
-- **Timeline Playback**: Play, pause, and loop your animation directly from the timeline to preview motion without leaving the editor.
+- **Timeline Playback**: Play, pause, and loop your animation directly from the timeline, adjusting FPS and total frames without leaving the editor.
 - **Selection Tools**: Tools for selecting parts of the image, including Rectangle, Circle, and Lasso selections.
 - **Image Manipulation**: Resize, crop, and flip the canvas.
 - **AI-Powered Image Generation**: Integrated with state-of-the-art AI models to generate images from text prompts.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pixel-Portal is a lightweight, cross-platform image editor built with Python and
 - **Drawing Tools**: A variety of tools for drawing and painting, including Pen, Bucket, Ellipse, Line, and Rectangle.
 - **Layer Management**: Full support for layers, allowing for complex image compositions. You can add, remove, reorder, and merge layers.
 - **Frame-aware Rendering**: Canvas compositing and drawing tools operate on the active frame so animation edits stay isolated.
+- **Timeline Playback**: Play, pause, and loop your animation directly from the timeline to preview motion without leaving the editor.
 - **Selection Tools**: Tools for selecting parts of the image, including Rectangle, Circle, and Lasso selections.
 - **Image Manipulation**: Resize, crop, and flip the canvas.
 - **AI-Powered Image Generation**: Integrated with state-of-the-art AI models to generate images from text prompts.

--- a/portal/core/animation_player.py
+++ b/portal/core/animation_player.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from PySide6.QtCore import QObject, QTimer, Signal
 
 
+DEFAULT_TOTAL_FRAMES = 24
+
+
 class AnimationPlayer(QObject):
     """Advance frames at a fixed rate and emit updates for listeners."""
 
@@ -15,7 +18,7 @@ class AnimationPlayer(QObject):
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
         self._fps = 12.0
-        self._total_frames = 1
+        self._total_frames = DEFAULT_TOTAL_FRAMES
         self._current_frame = 0
         self._is_playing = False
         self._timer = QTimer(self)

--- a/portal/core/animation_player.py
+++ b/portal/core/animation_player.py
@@ -1,0 +1,126 @@
+"""Timing helper for driving animation playback."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, QTimer, Signal
+
+
+class AnimationPlayer(QObject):
+    """Advance frames at a fixed rate and emit updates for listeners."""
+
+    frame_changed = Signal(int)
+    playing_changed = Signal(bool)
+    fps_changed = Signal(float)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._fps = 12.0
+        self._total_frames = 1
+        self._current_frame = 0
+        self._is_playing = False
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._advance_frame)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def fps(self) -> float:
+        return self._fps
+
+    @property
+    def total_frames(self) -> int:
+        return self._total_frames
+
+    @property
+    def current_frame(self) -> int:
+        return self._current_frame
+
+    @property
+    def is_playing(self) -> bool:
+        return self._is_playing
+
+    # ------------------------------------------------------------------
+    # Playback control
+    # ------------------------------------------------------------------
+    def play(self) -> None:
+        if self._is_playing:
+            return
+        if self._total_frames <= 0:
+            return
+        self._is_playing = True
+        self._timer.start(self._interval_for_fps())
+        self.playing_changed.emit(True)
+
+    def pause(self) -> None:
+        if not self._is_playing:
+            return
+        self._timer.stop()
+        self._is_playing = False
+        self.playing_changed.emit(False)
+
+    def stop(self) -> None:
+        was_playing = self._is_playing
+        self.pause()
+        if self._current_frame != 0 or was_playing:
+            self.set_current_frame(0)
+
+    def set_fps(self, fps: float) -> None:
+        try:
+            fps_value = float(fps)
+        except (TypeError, ValueError):
+            return
+        if fps_value <= 0:
+            fps_value = 1.0
+        if abs(fps_value - self._fps) < 1e-6:
+            return
+        self._fps = fps_value
+        if self._is_playing:
+            self._timer.start(self._interval_for_fps())
+        self.fps_changed.emit(self._fps)
+
+    def set_total_frames(self, frame_count: int) -> None:
+        frame_count = int(frame_count)
+        if frame_count < 1:
+            frame_count = 1
+        if frame_count == self._total_frames:
+            return
+        self._total_frames = frame_count
+        max_index = self._total_frames - 1
+        if self._current_frame > max_index:
+            self.set_current_frame(max_index)
+
+    def set_current_frame(self, frame: int) -> None:
+        if self._total_frames <= 0:
+            return
+        frame = int(frame)
+        max_index = self._total_frames - 1
+        if frame < 0:
+            frame = 0
+        elif frame > max_index:
+            frame = max_index
+        if frame == self._current_frame:
+            return
+        self._current_frame = frame
+        self.frame_changed.emit(self._current_frame)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _interval_for_fps(self) -> int:
+        if self._fps <= 0:
+            return 1000
+        return max(1, int(1000 / self._fps))
+
+    def _advance_frame(self) -> None:
+        if self._total_frames <= 0:
+            return
+        if self._total_frames == 1:
+            return
+        next_frame = self._current_frame + 1
+        if next_frame >= self._total_frames:
+            next_frame = 0
+        if next_frame == self._current_frame:
+            return
+        self._current_frame = next_frame
+        self.frame_changed.emit(self._current_frame)

--- a/tests/test_animation_player.py
+++ b/tests/test_animation_player.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QEventLoop, QTimer
+
+from portal.core.animation_player import AnimationPlayer
+
+
+def test_animation_player_advances_and_loops(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(3)
+    player.set_fps(60)
+
+    frames: list[int] = []
+    loop = QEventLoop()
+
+    def on_frame(frame: int) -> None:
+        frames.append(frame)
+        if len(frames) >= 4:
+            player.pause()
+            if loop.isRunning():
+                loop.quit()
+
+    player.frame_changed.connect(on_frame)
+    player.play()
+
+    QTimer.singleShot(500, loop.quit)
+    loop.exec()
+
+    assert len(frames) >= 4
+    assert frames[:4] == [1, 2, 0, 1]
+
+    player.stop()
+
+
+def test_animation_player_stop_resets_frame(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(5)
+    player.set_current_frame(3)
+
+    player.play()
+    qapp.processEvents()
+    player.stop()
+
+    assert player.current_frame == 0
+    assert not player.is_playing
+
+
+def test_animation_player_clamps_when_frame_count_shrinks(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(6)
+    player.set_current_frame(5)
+
+    observed: list[int] = []
+    player.frame_changed.connect(observed.append)
+
+    player.set_total_frames(3)
+
+    assert player.current_frame == 2
+    assert observed == [2]

--- a/tests/test_animation_player.py
+++ b/tests/test_animation_player.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from PySide6.QtCore import QEventLoop, QTimer
 
-from portal.core.animation_player import AnimationPlayer
+from portal.core.animation_player import AnimationPlayer, DEFAULT_TOTAL_FRAMES
+
+
+def test_animation_player_default_total_frames():
+    player = AnimationPlayer()
+    assert player.total_frames == DEFAULT_TOTAL_FRAMES
 
 
 def test_animation_player_advances_and_loops(qapp):

--- a/todo.txt
+++ b/todo.txt
@@ -4,3 +4,4 @@
 11. polygon create
 12. polygon select
 15. wire timeline UI to Document.add_layer_manager_listener for frame awareness (rendering/tools now use frame_manager.active_layer_manager)
+16. expand timeline playback controls (e.g. ping-pong, per-layer preview toggles)


### PR DESCRIPTION
## Summary
- add a reusable AnimationPlayer helper that emits frame, playback, and FPS updates for the timeline
- extend the timeline panel with play/pause, stop, and FPS controls that drive the canvas and follow document changes
- cover playback behaviour with Qt-based tests and mention the controls in the user docs and todo list

## Testing
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_animation_player.py

------
https://chatgpt.com/codex/tasks/task_e_68cabcab2cd88321adad0c09a7e47ced