### PR TITLE
Make selection state changes undoable

### DIFF
--- a/portal/commands/selection_commands.py
+++ b/portal/commands/selection_commands.py
@@ -1,13 +1,50 @@
 from portal.core.command import Command
-from PySide6.QtGui import QPainterPath, QImage, qRgba, qAlpha
+from PySide6.QtGui import QPainterPath, QImage, qAlpha
+
+
+def clone_selection_path(path: QPainterPath | None) -> QPainterPath | None:
+    if path is None:
+        return None
+    return QPainterPath(path)
+
+
+def selection_paths_equal(
+    first: QPainterPath | None, second: QPainterPath | None
+) -> bool:
+    if first is None or second is None:
+        return first is None and second is None
+    return first == second
+
+
+class SelectionChangeCommand(Command):
+    def __init__(
+        self,
+        canvas,
+        previous_selection: QPainterPath | None,
+        new_selection: QPainterPath | None,
+    ) -> None:
+        self.canvas = canvas
+        self.previous_selection = clone_selection_path(previous_selection)
+        self.new_selection = clone_selection_path(new_selection)
+
+    def execute(self) -> None:
+        self.canvas._update_selection_and_emit_size(
+            clone_selection_path(self.new_selection)
+        )
+
+    def undo(self) -> None:
+        self.canvas._update_selection_and_emit_size(
+            clone_selection_path(self.previous_selection)
+        )
+
 
 class SelectOpaqueCommand(Command):
-    def __init__(self, layer, canvas):
+    def __init__(self, layer, canvas) -> None:
         self.layer = layer
         self.canvas = canvas
-        self.previous_selection = self.canvas.selection_shape
+        self.previous_selection = clone_selection_path(self.canvas.selection_shape)
 
-    def execute(self):
+    def execute(self) -> None:
         path = QPainterPath()
         image = self.layer.image
         image = image.convertToFormat(QImage.Format_ARGB32)
@@ -19,5 +56,7 @@ class SelectOpaqueCommand(Command):
 
         self.canvas._update_selection_and_emit_size(path.simplified())
 
-    def undo(self):
-        self.canvas._update_selection_and_emit_size(self.previous_selection)
+    def undo(self) -> None:
+        self.canvas._update_selection_and_emit_size(
+            clone_selection_path(self.previous_selection)
+        )

--- a/portal/tools/selectcircletool.py
+++ b/portal/tools/selectcircletool.py
@@ -15,10 +15,11 @@ class SelectCircleTool(BaseSelectTool):
         self.start_point = QPoint()
 
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if not self.is_on_selection_border(doc_pos):
-            self.start_point = doc_pos
-            self.canvas._update_selection_and_emit_size(QPainterPath(self.start_point))
         super().mousePressEvent(event, doc_pos)
+        if self.moving_selection:
+            return
+        self.start_point = doc_pos
+        self.canvas._update_selection_and_emit_size(QPainterPath(self.start_point))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if not self.moving_selection:

--- a/portal/tools/selectlassotool.py
+++ b/portal/tools/selectlassotool.py
@@ -11,9 +11,10 @@ class SelectLassoTool(BaseSelectTool):
     category = "select"
 
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if not self.is_on_selection_border(doc_pos):
-            self.canvas._update_selection_and_emit_size(QPainterPath(doc_pos))
         super().mousePressEvent(event, doc_pos)
+        if self.moving_selection:
+            return
+        self.canvas._update_selection_and_emit_size(QPainterPath(doc_pos))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if not self.moving_selection:

--- a/portal/tools/selectrectangletool.py
+++ b/portal/tools/selectrectangletool.py
@@ -15,10 +15,11 @@ class SelectRectangleTool(BaseSelectTool):
         self.start_point = QPoint()
 
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if not self.is_on_selection_border(doc_pos):
-            self.start_point = doc_pos
-            self.canvas._update_selection_and_emit_size(QPainterPath(self.start_point))
         super().mousePressEvent(event, doc_pos)
+        if self.moving_selection:
+            return
+        self.start_point = doc_pos
+        self.canvas._update_selection_and_emit_size(QPainterPath(self.start_point))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if not self.moving_selection:


### PR DESCRIPTION
## Summary
- add a SelectionChangeCommand helper to snapshot selection paths and reuse it for selecting opaque pixels
- emit selection change commands from the base selection tools, color picker, and move tool so their edits are undoable
- wrap select all/none/invert canvas actions in the new command to keep menu-driven selection changes on the undo stack

## Testing
- python -m compileall portal

------
https://chatgpt.com/codex/tasks/task_e_68cabc6e6ce48321902a72982b055552