### PR TITLE
Fix merge down key union and add collapse menu action

### DIFF
--- a/portal/ui/layer_list_widget.py
+++ b/portal/ui/layer_list_widget.py
@@ -6,6 +6,7 @@ class LayerListWidget(QListWidget):
     select_opaque_requested = Signal(int)
     duplicate_requested = Signal(int)
     remove_background_requested = Signal(int)
+    collapse_requested = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -23,6 +24,9 @@ class LayerListWidget(QListWidget):
         select_opaque_action = menu.addAction("Select Opaque")
         duplicate_action = menu.addAction("Duplicate")
         remove_bg_action = menu.addAction("Remove Background")
+        menu.addSeparator()
+        collapse_action = menu.addAction("Collapse Layers")
+        collapse_action.setEnabled(self.count() > 1)
 
         action = menu.exec(self.mapToGlobal(pos))
 
@@ -34,6 +38,8 @@ class LayerListWidget(QListWidget):
             self.duplicate_requested.emit(index)
         elif action == remove_bg_action:
             self.remove_background_requested.emit(index)
+        elif action == collapse_action:
+            self.collapse_requested.emit()
 
     def mousePressEvent(self, event):
         if (

--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -34,6 +34,7 @@ class LayerManagerWidget(QWidget):
         self.layer_list.select_opaque_requested.connect(self.select_opaque)
         self.layer_list.duplicate_requested.connect(self.duplicate_layer_from_menu)
         self.layer_list.remove_background_requested.connect(self.remove_background_from_menu)
+        self.layer_list.collapse_requested.connect(self.collapse_layers_from_menu)
         self.layout.addWidget(self.layer_list)
 
         # Toolbar
@@ -233,9 +234,12 @@ class LayerManagerWidget(QWidget):
         self.app.execute_command(command)
 
     def merge_layer_down(self, index_in_list):
-        actual_index = len(self.app.document.layer_manager.layers) - 1 - index_in_list
+        document = self.app.document
+        if document is None:
+            return
+        actual_index = len(document.layer_manager.layers) - 1 - index_in_list
         from portal.commands.layer_commands import MergeLayerDownCommand
-        command = MergeLayerDownCommand(self.app.document.layer_manager, actual_index)
+        command = MergeLayerDownCommand(document, actual_index)
         self.app.execute_command(command)
 
     def select_opaque(self, index_in_list):
@@ -253,3 +257,11 @@ class LayerManagerWidget(QWidget):
         actual_index = len(self.app.document.layer_manager.layers) - 1 - index_in_list
         self.app.document.layer_manager.select_layer(actual_index)
         self.app.remove_background_from_layer()
+
+    def collapse_layers_from_menu(self):
+        document = self.app.document
+        if document is None:
+            return
+        from portal.commands.layer_commands import CollapseLayersCommand
+        command = CollapseLayersCommand(document)
+        self.app.execute_command(command)


### PR DESCRIPTION
## Summary
- ensure merging layers down unions their keyframe sets across the timeline and snapshot state for undo/redo
- add a collapse action that merges the entire stack and expose it from the layer list context menu
- cover the new behaviour with tests for merge-down and collapse across animated frames

## Testing
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py::test_merge_layer_down_unifies_keyframes
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py::test_collapse_layers_merges_entire_stack

------
https://chatgpt.com/codex/tasks/task_e_68cacd161448832189f478297afe80bb