### PR TITLE
Update timeline scrub indicator

### DIFF
--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -314,11 +314,15 @@ class AnimationTimelineWidget(QWidget):
 
     def mousePressEvent(self, event: QMouseEvent) -> None:  # noqa: N802 - Qt naming
         if event.button() == Qt.LeftButton:
+            modifiers = event.modifiers()
             key_frame = self._key_at_point(event)
             if key_frame is not None:
                 self._is_dragging = False
-                self._handle_key_click(key_frame, event.modifiers())
-                self.set_current_frame(key_frame)
+                self._handle_key_click(key_frame, modifiers)
+                ctrl_down = self._is_control_modifier(modifiers)
+                shift_down = bool(modifiers & Qt.ShiftModifier)
+                if not ctrl_down and not shift_down:
+                    self.set_current_frame(key_frame)
                 event.accept()
                 return
             if self._is_point_in_scrub_area(event):

--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -315,12 +315,12 @@ class AnimationTimelineWidget(QWidget):
     def mousePressEvent(self, event: QMouseEvent) -> None:  # noqa: N802 - Qt naming
         if event.button() == Qt.LeftButton:
             modifiers = event.modifiers()
+            ctrl_down = self._is_control_modifier(modifiers)
+            shift_down = bool(modifiers & Qt.ShiftModifier)
             key_frame = self._key_at_point(event)
             if key_frame is not None:
                 self._is_dragging = False
                 self._handle_key_click(key_frame, modifiers)
-                ctrl_down = self._is_control_modifier(modifiers)
-                shift_down = bool(modifiers & Qt.ShiftModifier)
                 if not ctrl_down and not shift_down:
                     self.set_current_frame(key_frame)
                 event.accept()
@@ -329,6 +329,10 @@ class AnimationTimelineWidget(QWidget):
                 self._is_dragging = True
                 frame = self._frame_at_point(event)
                 self.set_current_frame(frame)
+                event.accept()
+                return
+            if not ctrl_down and not shift_down:
+                self._set_selection(set(), anchor=None)
                 event.accept()
                 return
             self._is_dragging = False


### PR DESCRIPTION
## Summary
- replace the vertical current-frame line with a triangular indicator that sits inside new scrub guide lines on the animation timeline
- add geometry helpers for the scrub channel and render the parallel scrub lines beneath the timeline scale
- limit left-click scrubbing to the scrub channel so dragging only adjusts the frame when interacting with the scrub lines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caeb207af88321ac9ac33bb3ad0839