### PR TITLE
Add animation import workflow for animated images

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -35,6 +35,9 @@ class ActionManager:
         self.open_action.setShortcut("Ctrl+O")
         self.open_action.triggered.connect(self.app.document_service.open_document)
 
+        self.import_animation_action = QAction("Import Animation...", self.main_window)
+        self.import_animation_action.triggered.connect(self.app.document_service.import_animation)
+
         self.save_action = QAction(QIcon("icons/save.png"), "&Save", self.main_window)
         self.save_action.setShortcut("Ctrl+S")
         self.save_action.triggered.connect(self.app.document_service.save_document)

--- a/portal/commands/menu_bar_builder.py
+++ b/portal/commands/menu_bar_builder.py
@@ -26,6 +26,7 @@ class MenuBarBuilder:
         file_menu = menu_bar.addMenu("&File")
         file_menu.addAction(self.action_manager.new_action)
         file_menu.addAction(self.action_manager.open_action)
+        file_menu.addAction(self.action_manager.import_animation_action)
         file_menu.addAction(self.action_manager.save_action)
         file_menu.addSeparator()
         file_menu.addAction(self.action_manager.load_palette_action)

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -1,5 +1,5 @@
-from PySide6.QtGui import QImage
-from PySide6.QtWidgets import QFileDialog
+from PySide6.QtGui import QImage, QImageReader, QPainter
+from PySide6.QtWidgets import QFileDialog, QMessageBox
 import os
 
 from portal.core.document import Document
@@ -60,6 +60,147 @@ class DocumentService:
                 image.save(file_path)
 
             app.is_dirty = False
+
+    def import_animation(self):
+        app = self.app
+        if app is None:
+            return
+        if not app.check_for_unsaved_changes():
+            return
+
+        file_path, _ = QFileDialog.getOpenFileName(
+            None,
+            "Import Animation",
+            app.last_directory,
+            "Animation Files (*.gif *.apng *.png *.webp *.tif *.tiff);;All Files (*)",
+        )
+        if not file_path:
+            return
+
+        app.last_directory = os.path.dirname(file_path)
+        app.config.set('General', 'last_directory', app.last_directory)
+
+        try:
+            frames, fps = self._read_animation_frames(file_path)
+        except ValueError as exc:
+            parent = getattr(app, "main_window", None)
+            QMessageBox.warning(parent, "Import Animation", str(exc))
+            return
+
+        if not frames:
+            parent = getattr(app, "main_window", None)
+            QMessageBox.warning(
+                parent,
+                "Import Animation",
+                "No frames could be read from the selected file.",
+            )
+            return
+
+        try:
+            document = self._populate_document_with_frames(frames, os.path.basename(file_path))
+        except ValueError as exc:
+            parent = getattr(app, "main_window", None)
+            QMessageBox.warning(parent, "Import Animation", str(exc))
+            return
+
+        app.attach_document(document)
+        if app.main_window:
+            app.main_window.apply_imported_animation_metadata(len(frames), fps)
+        app.undo_manager.clear()
+        app.is_dirty = False
+        app.undo_stack_changed.emit()
+        app.document_changed.emit()
+        if app.main_window:
+            app.main_window.canvas.set_initial_zoom()
+
+    def _read_animation_frames(self, file_path):
+        reader = QImageReader(file_path)
+        reader.setDecideFormatFromContent(True)
+        if not reader.supportsAnimation():
+            raise ValueError("The selected file does not contain animation frames.")
+
+        frames: list[QImage] = []
+        delays: list[int] = []
+        while True:
+            image = reader.read()
+            if image.isNull():
+                if frames:
+                    break
+                message = reader.errorString() or "Unable to read image data."
+                raise ValueError(message)
+            converted = image.convertToFormat(QImage.Format_ARGB32)
+            frames.append(converted)
+            delays.append(reader.nextImageDelay())
+
+        base_width = frames[0].width()
+        base_height = frames[0].height()
+        normalized_frames: list[QImage] = []
+        for frame in frames:
+            if frame.width() == base_width and frame.height() == base_height:
+                normalized_frames.append(frame)
+                continue
+            canvas = QImage(base_width, base_height, QImage.Format_ARGB32)
+            canvas.fill(0)
+            painter = QPainter(canvas)
+            painter.drawImage(0, 0, frame)
+            painter.end()
+            normalized_frames.append(canvas)
+
+        valid_delays = [delay for delay in delays if delay and delay > 0]
+        if valid_delays:
+            average = sum(valid_delays) / len(valid_delays)
+            fps = 1000.0 / average if average > 0 else 12.0
+        else:
+            fps = 12.0
+
+        return normalized_frames, fps
+
+    def _populate_document_with_frames(self, frames, filename):
+        if not frames:
+            raise ValueError("No frames available to import.")
+
+        width = frames[0].width()
+        height = frames[0].height()
+        document = Document(width, height)
+        layer_manager = document.layer_manager
+        active_layer = layer_manager.active_layer
+        if active_layer is None:
+            layer_manager.add_layer("Animation")
+            active_layer = layer_manager.active_layer
+        if active_layer is None:
+            raise ValueError("Unable to create a layer for the imported animation.")
+
+        base_name = os.path.splitext(filename)[0]
+        if base_name:
+            try:
+                active_layer.name = base_name
+            except ValueError:
+                pass
+
+        frame_manager = document.frame_manager
+        layer_uid = active_layer.uid
+        for index, frame in enumerate(frames):
+            frame_manager.ensure_frame(index)
+            if index not in frame_manager.layer_keys.get(layer_uid, {0}):
+                frame_manager.add_layer_key(layer_uid, index)
+            target_layer = self._layer_instance_for_frame(frame_manager, index, layer_uid)
+            if target_layer is None:
+                continue
+            target_layer.image = frame.copy()
+            target_layer.on_image_change.emit()
+
+        document.select_frame(0)
+        return document
+
+    @staticmethod
+    def _layer_instance_for_frame(frame_manager, frame_index, layer_uid):
+        if not (0 <= frame_index < len(frame_manager.frames)):
+            return None
+        manager = frame_manager.frames[frame_index].layer_manager
+        for layer in manager.layers:
+            if getattr(layer, "uid", None) == layer_uid:
+                return layer
+        return None
 
     def _get_selected_image(self):
         app = self.app

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -350,6 +350,19 @@ class MainWindow(QMainWindow):
             self.animation_player.set_current_frame(current_frame)
         self._update_stop_button_state()
 
+    def apply_imported_animation_metadata(self, frame_count: int, fps: float) -> None:
+        frame_total = max(1, int(frame_count))
+        with QSignalBlocker(self.timeline_total_frames_spinbox):
+            self.timeline_total_frames_spinbox.setValue(frame_total)
+        self._on_timeline_total_frames_changed(frame_total)
+
+        if isinstance(fps, (int, float)):
+            fps_value = float(fps)
+        else:
+            fps_value = self.animation_player.fps
+        fps_value = max(1.0, min(60.0, fps_value))
+        self.animation_player.set_fps(fps_value)
+
     @Slot(bool)
     def _on_player_state_changed(self, playing: bool) -> None:
         with QSignalBlocker(self.timeline_play_button):


### PR DESCRIPTION
## Summary
- add an "Import Animation..." entry to the File menu and action manager
- read animated image frames with QImageReader, build a multi-frame document, and attach it to the app
- update the timeline playback controls with imported frame count and fps metadata

## Testing
- python -m compileall portal

------
https://chatgpt.com/codex/tasks/task_e_68caeff9859883218c0a5fe52e8c103a