### PR TITLE
Add non-modal dialog for background removal scopes

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -124,7 +124,9 @@ class ActionManager:
         self.conform_to_palette_action.triggered.connect(self.app.conform_to_palette)
 
         self.remove_background_action = QAction("Remove Background", self.main_window)
-        self.remove_background_action.triggered.connect(self.app.remove_background_from_layer)
+        self.remove_background_action.triggered.connect(
+            self.main_window.open_remove_background_dialog
+        )
         self.remove_background_action.setEnabled(REMBG_AVAILABLE)
         if not REMBG_AVAILABLE:
             self.remove_background_action.setToolTip(

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -3,7 +3,7 @@ from typing import Optional
 from PySide6.QtCore import QObject, Signal, Slot
 import os
 
-from portal.core.document_controller import DocumentController
+from portal.core.document_controller import DocumentController, BackgroundRemovalScope
 from portal.core.settings_controller import SettingsController
 from portal.core.scripting import ScriptingAPI
 from portal.ui.script_dialog import ScriptDialog
@@ -230,8 +230,13 @@ class App(QObject):
         palette_hex = self.main_window.get_palette()
         self.document_controller.conform_to_palette(palette_hex)
 
-    def remove_background_from_layer(self):
-        self.document_controller.remove_background_from_layer()
+    def remove_background_from_layer(
+        self, scope: BackgroundRemovalScope | None = None
+    ):
+        if scope is None:
+            self.document_controller.remove_background_from_layer()
+        else:
+            self.document_controller.remove_background_from_layer(scope)
 
     def run_script(self, script_path):
         """Runs a script with optional parameters and undo support."""

--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -256,7 +256,9 @@ class LayerManagerWidget(QWidget):
     def remove_background_from_menu(self, index_in_list):
         actual_index = len(self.app.document.layer_manager.layers) - 1 - index_in_list
         self.app.document.layer_manager.select_layer(actual_index)
-        self.app.remove_background_from_layer()
+        main_window = getattr(self.app, "main_window", None)
+        if main_window is not None:
+            main_window.open_remove_background_dialog()
 
     def collapse_layers_from_menu(self):
         document = self.app.document

--- a/portal/ui/remove_background_dialog.py
+++ b/portal/ui/remove_background_dialog.py
@@ -1,0 +1,66 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QRadioButton,
+    QVBoxLayout,
+)
+
+from portal.core.document_controller import BackgroundRemovalScope
+
+
+class RemoveBackgroundDialog(QDialog):
+    """Configure how background removal should be applied to the active layer."""
+
+    def __init__(self, app, parent=None):
+        super().__init__(parent)
+        self.app = app
+
+        self.setWindowTitle("Remove Background")
+        self.setModal(False)
+        self.setWindowModality(Qt.NonModal)
+
+        layout = QVBoxLayout(self)
+        description = QLabel(
+            "Choose whether to remove the background from the current key or all keys.",
+            self,
+        )
+        description.setWordWrap(True)
+        layout.addWidget(description)
+
+        self.button_group = QButtonGroup(self)
+        self.all_keys_radio = QRadioButton("All keys", self)
+        self.this_key_radio = QRadioButton("This key", self)
+        self.button_group.addButton(self.all_keys_radio)
+        self.button_group.addButton(self.this_key_radio)
+        self.all_keys_radio.setChecked(True)
+
+        layout.addWidget(self.all_keys_radio)
+        layout.addWidget(self.this_key_radio)
+
+        self.button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel | QDialogButtonBox.Apply,
+            parent=self,
+        )
+        self.button_box.accepted.connect(self._apply_and_close)
+        self.button_box.rejected.connect(self.reject)
+        apply_button = self.button_box.button(QDialogButtonBox.Apply)
+        if apply_button is not None:
+            apply_button.clicked.connect(self.apply)
+        layout.addWidget(self.button_box)
+
+    def current_scope(self) -> BackgroundRemovalScope:
+        if self.this_key_radio.isChecked():
+            return BackgroundRemovalScope.THIS_KEY
+        return BackgroundRemovalScope.ALL_KEYS
+
+    def apply(self):
+        scope = self.current_scope()
+        if self.app is not None:
+            self.app.remove_background_from_layer(scope)
+
+    def _apply_and_close(self):
+        self.apply()
+        self.accept()

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -38,6 +38,7 @@ from portal.commands.tool_bar_builder import ToolBarBuilder
 from portal.commands.status_bar_manager import StatusBarManager
 from portal.ui.flip_dialog import FlipDialog
 from portal.ui.settings_dialog import SettingsDialog
+from portal.ui.remove_background_dialog import RemoveBackgroundDialog
 
 
 from PySide6.QtWidgets import QColorDialog
@@ -54,6 +55,8 @@ class MainWindow(QMainWindow):
         self.action_manager = ActionManager(self)
 
         self.main_palette_buttons = []
+
+        self.remove_background_dialog = None
 
         self.canvas = Canvas(self.app.drawing_context)
         self.canvas.set_background_image_alpha(
@@ -649,6 +652,13 @@ class MainWindow(QMainWindow):
         dialog = SettingsDialog(self.app.settings_controller, self)
         dialog.settings_applied.connect(self.apply_settings_from_controller)
         dialog.exec()
+
+    def open_remove_background_dialog(self):
+        if self.remove_background_dialog is None:
+            self.remove_background_dialog = RemoveBackgroundDialog(self.app, self)
+        self.remove_background_dialog.show()
+        self.remove_background_dialog.raise_()
+        self.remove_background_dialog.activateWindow()
 
     @Slot()
     def apply_settings_from_controller(self):


### PR DESCRIPTION
## Summary
- replace the remove background action with a reusable, non-modal dialog that offers "All keys" or "This key" scopes
- extend the document controller so background removal can target the active key or every keyed frame via composite commands
- wire the dialog into the main window and layer list context menu so it can be reopened across frames

## Testing
- python -m compileall portal/commands/action_manager.py portal/core/app.py portal/core/document_controller.py portal/ui/remove_background_dialog.py portal/ui/layer_manager_widget.py portal/ui/ui.py

------
https://chatgpt.com/codex/tasks/task_e_68cb092dae388321b4f94692d46ae3bd