### PR TITLE
Propagate layer reorder across frames

### DIFF
--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -160,7 +160,8 @@ class LayerManagerWidget(QWidget):
             # No effective change.
             return
 
-        layer_manager = self.app.document.layer_manager
+        document = self.app.document
+        layer_manager = document.layer_manager
         total_layers = len(layer_manager.layers)
 
         from_index = total_layers - 1 - start
@@ -171,7 +172,7 @@ class LayerManagerWidget(QWidget):
 
         from portal.core.command import MoveLayerCommand
 
-        command = MoveLayerCommand(layer_manager, from_index, to_index)
+        command = MoveLayerCommand(document, from_index, to_index)
         self.app.execute_command(command)
 
         # Ensure the canvas reflects the new layer order immediately.
@@ -221,7 +222,7 @@ class LayerManagerWidget(QWidget):
         actual_index = len(self.app.document.layer_manager.layers) - 1 - current_row
         
         from portal.core.command import MoveLayerCommand
-        command = MoveLayerCommand(self.app.document.layer_manager, actual_index, actual_index + 1)
+        command = MoveLayerCommand(self.app.document, actual_index, actual_index + 1)
         self.app.execute_command(command)
 
     def move_layer_down(self):
@@ -230,7 +231,7 @@ class LayerManagerWidget(QWidget):
         actual_index = len(self.app.document.layer_manager.layers) - 1 - current_row
         
         from portal.core.command import MoveLayerCommand
-        command = MoveLayerCommand(self.app.document.layer_manager, actual_index, actual_index - 1)
+        command = MoveLayerCommand(self.app.document, actual_index, actual_index - 1)
         self.app.execute_command(command)
 
     def merge_layer_down(self, index_in_list):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -709,18 +709,30 @@ def test_move_layer_command(document):
         layer_manager.active_layer_index,
     )
 
+    # Ensure an additional frame exists so the command must propagate ordering changes.
+    document.frame_manager.ensure_frame(1)
+    second_manager = document.frame_manager.frames[1].layer_manager
+
     original_layers = list(layer_manager.layers)
+    original_second_order = list(second_manager.layers)
+
     from_index = 0
     to_index = 2
 
-    command = MoveLayerCommand(layer_manager, from_index, to_index)
+    command = MoveLayerCommand(document, from_index, to_index)
     command.execute()
 
     assert layer_manager.layers[to_index] == original_layers[from_index]
+    assert [layer.uid for layer in second_manager.layers] == [
+        layer.uid for layer in layer_manager.layers
+    ]
 
     command.undo()
 
     assert layer_manager.layers == original_layers
+    assert [layer.uid for layer in second_manager.layers] == [
+        layer.uid for layer in original_second_order
+    ]
 
 def test_fill_command(document, layer):
     """Test that the FillCommand correctly fills an area and that undo restores the previous state."""


### PR DESCRIPTION
## Summary
- update `MoveLayerCommand` to reorder layers across all frames while preserving active selections
- adjust the layer list widget to invoke the command with the document reference
- extend the move layer unit test to cover frame synchronization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb130c3e48832180bbe6d1c90d36c5