### PR TITLE
Refactor tool preview management and extend drawing tool tests

### DIFF
--- a/portal/tools/basetool.py
+++ b/portal/tools/basetool.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import QPoint, Qt, QObject, Signal
-from PySide6.QtGui import QMouseEvent, QCursor
+from PySide6.QtGui import QMouseEvent, QCursor, QImage
 
 from portal.core.frame_manager import resolve_active_layer_manager
 
@@ -41,6 +41,70 @@ class BaseTool(QObject):
     def draw_overlay(self, painter):
         """Called when the canvas is being painted."""
         pass
+
+    # Preview helpers -----------------------------------------------------
+    def _allocate_preview_images(
+        self,
+        *,
+        replace_active_layer: bool = False,
+        allocate_temp: bool = True,
+        erase_preview: bool = False,
+    ):
+        """Prepare temporary and tile preview images for live rendering."""
+
+        canvas = self.canvas
+        canvas.temp_image_replaces_active_layer = replace_active_layer
+
+        if allocate_temp:
+            canvas.temp_image = QImage(canvas._document_size, QImage.Format_ARGB32)
+            canvas.temp_image.fill(Qt.transparent)
+        else:
+            canvas.temp_image = None
+
+        if erase_preview:
+            canvas.is_erasing_preview = True
+        else:
+            # Ensure the attribute is reset even if the caller never touches it.
+            canvas.is_erasing_preview = False
+
+        if canvas.tile_preview_enabled:
+            canvas.tile_preview_image = QImage(canvas._document_size, QImage.Format_ARGB32)
+            canvas.tile_preview_image.fill(Qt.transparent)
+        else:
+            canvas.tile_preview_image = None
+
+    def _refresh_preview_images(
+        self,
+        *,
+        clear_temp: bool = True,
+        clear_tile_preview: bool = True,
+    ):
+        """Clear preview buffers so they can be redrawn."""
+
+        canvas = self.canvas
+        if clear_temp and canvas.temp_image is not None:
+            canvas.temp_image.fill(Qt.transparent)
+
+        if not clear_tile_preview:
+            return
+
+        if canvas.tile_preview_enabled:
+            if canvas.tile_preview_image is None:
+                canvas.tile_preview_image = QImage(canvas._document_size, QImage.Format_ARGB32)
+            canvas.tile_preview_image.fill(Qt.transparent)
+        else:
+            canvas.tile_preview_image = None
+
+    def _clear_preview_images(self, *, clear_original: bool = True):
+        """Reset preview buffers to an idle state."""
+
+        canvas = self.canvas
+        canvas.temp_image = None
+        if clear_original:
+            canvas.original_image = None
+        canvas.tile_preview_image = None
+        canvas.temp_image_replaces_active_layer = False
+        canvas.is_erasing_preview = False
 
     def _get_active_layer_manager(self):
         document = getattr(self.canvas, "document", None)

--- a/portal/tools/linetool.py
+++ b/portal/tools/linetool.py
@@ -17,59 +17,30 @@ class LineTool(BaseTool):
 
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
         self.start_point = doc_pos
-        self.canvas.temp_image_replaces_active_layer = True
+        self._allocate_preview_images(replace_active_layer=True, allocate_temp=False)
         self.command_generated.emit(("get_active_layer_image", "line_tool_start"))
-        if self.canvas.tile_preview_enabled:
-            self.canvas.tile_preview_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
-            self.canvas.tile_preview_image.fill(Qt.transparent)
-        else:
-            self.canvas.tile_preview_image = None
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if self.canvas.original_image is None:
             return
 
         self.canvas.temp_image = self.canvas.original_image.copy()
-        painter = QPainter(self.canvas.temp_image)
-        if self.canvas.selection_shape:
-            painter.setClipPath(self.canvas.selection_shape)
-        painter.setPen(QPen(self.canvas.drawing_context.pen_color))
-        self.canvas.drawing.draw_line_with_brush(
-            painter,
-            self.start_point,
-            doc_pos,
-            self.canvas._document_size,
-            self.canvas.drawing_context.brush_type,
-            self.canvas.drawing_context.pen_width,
-            self.canvas.drawing_context.mirror_x,
-            self.canvas.drawing_context.mirror_y,
+        self._refresh_preview_images(clear_temp=False)
+        self._paint_preview_line(
+            self.canvas.temp_image,
             wrap=self.canvas.tile_preview_enabled,
-            pattern=self.canvas.drawing_context.pattern_brush,
-            mirror_x_position=self.canvas.drawing_context.mirror_x_position,
-            mirror_y_position=self.canvas.drawing_context.mirror_y_position,
+            start=self.start_point,
+            end=doc_pos,
         )
-        painter.end()
-        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
-            self.canvas.tile_preview_image.fill(Qt.transparent)
-            preview_painter = QPainter(self.canvas.tile_preview_image)
-            if self.canvas.selection_shape:
-                preview_painter.setClipPath(self.canvas.selection_shape)
-            preview_painter.setPen(QPen(self.canvas.drawing_context.pen_color))
-            self.canvas.drawing.draw_line_with_brush(
-                preview_painter,
-                self.start_point,
-                doc_pos,
-                self.canvas._document_size,
-                self.canvas.drawing_context.brush_type,
-                self.canvas.drawing_context.pen_width,
-                self.canvas.drawing_context.mirror_x,
-                self.canvas.drawing_context.mirror_y,
+
+        tile_preview = self.canvas.tile_preview_image
+        if tile_preview is not None:
+            self._paint_preview_line(
+                tile_preview,
                 wrap=True,
-                pattern=self.canvas.drawing_context.pattern_brush,
-                mirror_x_position=self.canvas.drawing_context.mirror_x_position,
-                mirror_y_position=self.canvas.drawing_context.mirror_y_position,
+                start=self.start_point,
+                end=doc_pos,
             )
-            preview_painter.end()
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
@@ -78,10 +49,7 @@ class LineTool(BaseTool):
 
         layer_manager = self._get_active_layer_manager()
         if layer_manager is None:
-            self.canvas.temp_image = None
-            self.canvas.original_image = None
-            self.canvas.temp_image_replaces_active_layer = False
-            self.canvas.tile_preview_image = None
+            self._clear_preview_images()
             self.canvas.update()
             return
 
@@ -107,8 +75,33 @@ class LineTool(BaseTool):
         )
         self.command_generated.emit(command)
 
-        self.canvas.temp_image = None
-        self.canvas.original_image = None
-        self.canvas.temp_image_replaces_active_layer = False
-        self.canvas.tile_preview_image = None
+        self._clear_preview_images()
         self.canvas.update()
+
+    def _paint_preview_line(
+        self,
+        image: QImage,
+        *,
+        wrap: bool,
+        start: QPoint,
+        end: QPoint,
+    ):
+        painter = QPainter(image)
+        if self.canvas.selection_shape:
+            painter.setClipPath(self.canvas.selection_shape)
+        painter.setPen(QPen(self.canvas.drawing_context.pen_color))
+        self.canvas.drawing.draw_line_with_brush(
+            painter,
+            start,
+            end,
+            self.canvas._document_size,
+            self.canvas.drawing_context.brush_type,
+            self.canvas.drawing_context.pen_width,
+            self.canvas.drawing_context.mirror_x,
+            self.canvas.drawing_context.mirror_y,
+            wrap=wrap,
+            pattern=self.canvas.drawing_context.pattern_brush,
+            mirror_x_position=self.canvas.drawing_context.mirror_x_position,
+            mirror_y_position=self.canvas.drawing_context.mirror_y_position,
+        )
+        painter.end()

--- a/portal/tools/pentool.py
+++ b/portal/tools/pentool.py
@@ -26,18 +26,8 @@ class PenTool(BaseTool):
 
         self.points = [doc_pos]
 
-        # Use a transparent temp image for the preview overlay
-        self.canvas.temp_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
-        self.canvas.temp_image.fill(Qt.transparent)
-
-        if self.canvas.tile_preview_enabled:
-            self.canvas.tile_preview_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
-            self.canvas.tile_preview_image.fill(Qt.transparent)
-        else:
-            self.canvas.tile_preview_image = None
-
-        # This flag tells the renderer to draw our temp_image ON TOP of the document, not instead of it.
-        self.canvas.temp_image_replaces_active_layer = False
+        # Prepare transparent overlays for the live preview.
+        self._allocate_preview_images(replace_active_layer=False, allocate_temp=True)
 
         self.draw_path_on_temp_image()
         self.canvas.update()
@@ -62,10 +52,7 @@ class PenTool(BaseTool):
         if not self.points:
             # Clean up preview and return
             self.points = []
-            self.canvas.temp_image = None
-            self.canvas.original_image = None
-            self.canvas.temp_image_replaces_active_layer = False
-            self.canvas.tile_preview_image = None
+            self._clear_preview_images()
             self.canvas.update()
             return
 
@@ -73,10 +60,7 @@ class PenTool(BaseTool):
         if layer_manager is None:
             # Clean up preview and return
             self.points = []
-            self.canvas.temp_image = None
-            self.canvas.original_image = None
-            self.canvas.temp_image_replaces_active_layer = False
-            self.canvas.tile_preview_image = None
+            self._clear_preview_images()
             self.canvas.update()
             return
 
@@ -84,10 +68,7 @@ class PenTool(BaseTool):
         if not active_layer:
             # Clean up preview and return
             self.points = []
-            self.canvas.temp_image = None
-            self.canvas.original_image = None
-            self.canvas.temp_image_replaces_active_layer = False
-            self.canvas.tile_preview_image = None
+            self._clear_preview_images()
             self.canvas.update()
             return
 
@@ -111,31 +92,27 @@ class PenTool(BaseTool):
 
         # Clean up preview
         self.points = []
-        self.canvas.temp_image = None
-        self.canvas.original_image = None
-        self.canvas.temp_image_replaces_active_layer = False
-        self.canvas.tile_preview_image = None
+        self._clear_preview_images()
         self.canvas.update()
 
     def draw_path_on_temp_image(self):
         if not self.points or self.canvas.temp_image is None:
             return
 
-        # Clear the temp image before redrawing the path
-        self.canvas.temp_image.fill(Qt.transparent)
-        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
-            self.canvas.tile_preview_image.fill(Qt.transparent)
+        self._refresh_preview_images()
 
-        painter = QPainter(self.canvas.temp_image)
+        self._paint_preview_path(self.canvas.temp_image, wrap=self.canvas.tile_preview_enabled)
 
-        # Handle selection mask
+        tile_preview = self.canvas.tile_preview_image
+        if tile_preview is not None:
+            self._paint_preview_path(tile_preview, wrap=True)
+
+    def _paint_preview_path(self, image: QImage, *, wrap: bool):
+        painter = QPainter(image)
         if self.canvas.selection_shape:
             painter.setClipPath(self.canvas.selection_shape)
-        
-        # Set the pen for the live preview
         painter.setPen(QPen(self.canvas.drawing_context.pen_color))
-        
-        # Use the drawing class to handle mirroring and brush styles
+
         if len(self.points) == 1:
             self.canvas.drawing.draw_brush(
                 painter,
@@ -145,66 +122,27 @@ class PenTool(BaseTool):
                 self.canvas.drawing_context.pen_width,
                 self.canvas.drawing_context.mirror_x,
                 self.canvas.drawing_context.mirror_y,
-                wrap=self.canvas.tile_preview_enabled,
+                wrap=wrap,
                 pattern=self.canvas.drawing_context.pattern_brush,
                 mirror_x_position=self.canvas.drawing_context.mirror_x_position,
                 mirror_y_position=self.canvas.drawing_context.mirror_y_position,
             )
         else:
-            for i in range(len(self.points) - 1):
+            for start, end in zip(self.points, self.points[1:]):
                 self.canvas.drawing.draw_line_with_brush(
                     painter,
-                    self.points[i],
-                    self.points[i+1],
+                    start,
+                    end,
                     self.canvas._document_size,
                     self.canvas.drawing_context.brush_type,
                     self.canvas.drawing_context.pen_width,
                     self.canvas.drawing_context.mirror_x,
                     self.canvas.drawing_context.mirror_y,
-                    wrap=self.canvas.tile_preview_enabled,
+                    wrap=wrap,
                     erase=False,
                     pattern=self.canvas.drawing_context.pattern_brush,
                     mirror_x_position=self.canvas.drawing_context.mirror_x_position,
                     mirror_y_position=self.canvas.drawing_context.mirror_y_position,
                 )
-
         painter.end()
 
-        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
-            preview_painter = QPainter(self.canvas.tile_preview_image)
-            if self.canvas.selection_shape:
-                preview_painter.setClipPath(self.canvas.selection_shape)
-            preview_painter.setPen(QPen(self.canvas.drawing_context.pen_color))
-            if len(self.points) == 1:
-                self.canvas.drawing.draw_brush(
-                    preview_painter,
-                    self.points[0],
-                    self.canvas._document_size,
-                    self.canvas.drawing_context.brush_type,
-                    self.canvas.drawing_context.pen_width,
-                    self.canvas.drawing_context.mirror_x,
-                    self.canvas.drawing_context.mirror_y,
-                    wrap=True,
-                    pattern=self.canvas.drawing_context.pattern_brush,
-                    mirror_x_position=self.canvas.drawing_context.mirror_x_position,
-                    mirror_y_position=self.canvas.drawing_context.mirror_y_position,
-                )
-            else:
-                for i in range(len(self.points) - 1):
-                    self.canvas.drawing.draw_line_with_brush(
-                        preview_painter,
-                        self.points[i],
-                        self.points[i + 1],
-                        self.canvas._document_size,
-                        self.canvas.drawing_context.brush_type,
-                        self.canvas.drawing_context.pen_width,
-                        self.canvas.drawing_context.mirror_x,
-                        self.canvas.drawing_context.mirror_y,
-                        wrap=True,
-                        erase=False,
-                        pattern=self.canvas.drawing_context.pattern_brush,
-                        mirror_x_position=self.canvas.drawing_context.mirror_x_position,
-                        mirror_y_position=self.canvas.drawing_context.mirror_y_position,
-                    )
-            preview_painter.end()
-        

--- a/portal/tools/rectangletool.py
+++ b/portal/tools/rectangletool.py
@@ -26,13 +26,8 @@ class RectangleTool(BaseTool):
             return
 
         self.start_point = doc_pos
-        self.canvas.temp_image_replaces_active_layer = True
+        self._allocate_preview_images(replace_active_layer=True, allocate_temp=False)
         self.command_generated.emit(("get_active_layer_image", "rectangle_tool_start"))
-        if self.canvas.tile_preview_enabled:
-            self.canvas.tile_preview_image = QImage(self.canvas._document_size, QImage.Format_ARGB32)
-            self.canvas.tile_preview_image.fill(Qt.transparent)
-        else:
-            self.canvas.tile_preview_image = None
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if self.canvas.original_image is None:
@@ -47,10 +42,7 @@ class RectangleTool(BaseTool):
             return
 
         self.canvas.temp_image = self.canvas.original_image.copy()
-        painter = QPainter(self.canvas.temp_image)
-        if self.canvas.selection_shape:
-            painter.setClipPath(self.canvas.selection_shape)
-        painter.setPen(QPen(self.canvas.drawing_context.pen_color))
+        self._refresh_preview_images(clear_temp=False)
 
         end_point = doc_pos
         if event.modifiers() & Qt.ShiftModifier:
@@ -63,40 +55,15 @@ class RectangleTool(BaseTool):
             )
 
         rect = QRect(self.start_point, end_point).normalized()
-        self.canvas.drawing.draw_rect(
-            painter,
-            rect,
-            self.canvas._document_size,
-            self.canvas.drawing_context.brush_type,
-            self.canvas.drawing_context.pen_width,
-            self.canvas.drawing_context.mirror_x,
-            self.canvas.drawing_context.mirror_y,
+        self._paint_preview_rect(
+            self.canvas.temp_image,
+            rect=rect,
             wrap=self.canvas.tile_preview_enabled,
-            pattern=self.canvas.drawing_context.pattern_brush,
-            mirror_x_position=self.canvas.drawing_context.mirror_x_position,
-            mirror_y_position=self.canvas.drawing_context.mirror_y_position,
         )
-        painter.end()
-        if self.canvas.tile_preview_enabled and self.canvas.tile_preview_image is not None:
-            self.canvas.tile_preview_image.fill(Qt.transparent)
-            preview_painter = QPainter(self.canvas.tile_preview_image)
-            if self.canvas.selection_shape:
-                preview_painter.setClipPath(self.canvas.selection_shape)
-            preview_painter.setPen(QPen(self.canvas.drawing_context.pen_color))
-            self.canvas.drawing.draw_rect(
-                preview_painter,
-                rect,
-                self.canvas._document_size,
-                self.canvas.drawing_context.brush_type,
-                self.canvas.drawing_context.pen_width,
-                self.canvas.drawing_context.mirror_x,
-                self.canvas.drawing_context.mirror_y,
-                wrap=True,
-                pattern=self.canvas.drawing_context.pattern_brush,
-                mirror_x_position=self.canvas.drawing_context.mirror_x_position,
-                mirror_y_position=self.canvas.drawing_context.mirror_y_position,
-            )
-            preview_painter.end()
+
+        tile_preview = self.canvas.tile_preview_image
+        if tile_preview is not None:
+            self._paint_preview_rect(tile_preview, rect=rect, wrap=True)
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
@@ -117,10 +84,7 @@ class RectangleTool(BaseTool):
 
         layer_manager = self._get_active_layer_manager()
         if layer_manager is None:
-            self.canvas.temp_image = None
-            self.canvas.original_image = None
-            self.canvas.temp_image_replaces_active_layer = False
-            self.canvas.tile_preview_image = None
+            self._clear_preview_images()
             self.canvas.update()
             return
 
@@ -146,8 +110,25 @@ class RectangleTool(BaseTool):
         )
         self.command_generated.emit(command)
 
-        self.canvas.temp_image = None
-        self.canvas.original_image = None
-        self.canvas.temp_image_replaces_active_layer = False
-        self.canvas.tile_preview_image = None
+        self._clear_preview_images()
         self.canvas.update()
+
+    def _paint_preview_rect(self, image: QImage, *, rect: QRect, wrap: bool):
+        painter = QPainter(image)
+        if self.canvas.selection_shape:
+            painter.setClipPath(self.canvas.selection_shape)
+        painter.setPen(QPen(self.canvas.drawing_context.pen_color))
+        self.canvas.drawing.draw_rect(
+            painter,
+            rect,
+            self.canvas._document_size,
+            self.canvas.drawing_context.brush_type,
+            self.canvas.drawing_context.pen_width,
+            self.canvas.drawing_context.mirror_x,
+            self.canvas.drawing_context.mirror_y,
+            wrap=wrap,
+            pattern=self.canvas.drawing_context.pattern_brush,
+            mirror_x_position=self.canvas.drawing_context.mirror_x_position,
+            mirror_y_position=self.canvas.drawing_context.mirror_y_position,
+        )
+        painter.end()


### PR DESCRIPTION
## Summary
- add reusable helper methods on `BaseTool` to allocate, refresh, and clear preview overlays
- refactor pen, eraser, line, rectangle, and ellipse tools to use the helpers for both normal and tile-preview rendering
- expand drawing tool tests to verify tile preview overlays, eraser preview flags, and composite move commands

## Testing
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_drawing_tools.py

------
https://chatgpt.com/codex/tasks/task_e_68cb1a398fa483219a204c9adfb7cf98