### PR TITLE
Add modifier support for combining selections

### DIFF
--- a/portal/tools/selectcircletool.py
+++ b/portal/tools/selectcircletool.py
@@ -20,7 +20,7 @@ class SelectCircleTool(BaseSelectTool):
             return
         clamped_start = self._clamp_to_document(doc_pos)
         self.start_point = clamped_start
-        self.canvas._update_selection_and_emit_size(QPainterPath(clamped_start))
+        self._preview_selection_path(QPainterPath(clamped_start))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if not self.moving_selection:
@@ -47,7 +47,7 @@ class SelectCircleTool(BaseSelectTool):
                 doc_rect = QRect(0, 0, size.width(), size.height())
                 rect = rect.intersected(doc_rect)
             qpp.addEllipse(rect)
-            self.canvas._update_selection_and_emit_size(qpp)
+            self._preview_selection_path(qpp)
         super().mouseMoveEvent(event, doc_pos)
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):

--- a/portal/tools/selectlassotool.py
+++ b/portal/tools/selectlassotool.py
@@ -10,28 +10,31 @@ class SelectLassoTool(BaseSelectTool):
     shortcut = "f"
     category = "select"
 
+    def __init__(self, canvas):
+        super().__init__(canvas)
+        self._lasso_path: QPainterPath | None = None
+
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
         super().mousePressEvent(event, doc_pos)
         if self.moving_selection:
             return
         clamped_pos = self._clamp_to_document(doc_pos)
-        self.canvas._update_selection_and_emit_size(QPainterPath(clamped_pos))
+        self._lasso_path = QPainterPath(clamped_pos)
+        self._preview_selection_path(self._lasso_path)
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if not self.moving_selection:
-            if self.canvas.selection_shape:
-                clamped_pos = self._clamp_to_document(
-                    doc_pos, extend_max=True
-                )
-                self.canvas.selection_shape.lineTo(clamped_pos)
-                self.canvas._update_selection_and_emit_size(self.canvas.selection_shape)
+        if not self.moving_selection and self._lasso_path is not None:
+            clamped_pos = self._clamp_to_document(doc_pos, extend_max=True)
+            self._lasso_path.lineTo(clamped_pos)
+            self._preview_selection_path(self._lasso_path)
         super().mouseMoveEvent(event, doc_pos)
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if not self.moving_selection:
-            if self.canvas.selection_shape:
-                self.canvas.selection_shape.closeSubpath()
-                if self.canvas.selection_shape.isEmpty():
-                    self.canvas.selection_shape = None
+        if not self.moving_selection and self._lasso_path is not None:
+            self._lasso_path.closeSubpath()
+            self._preview_selection_path(self._lasso_path)
+            if self.canvas.selection_shape and self.canvas.selection_shape.isEmpty():
+                self.canvas.selection_shape = None
             self.canvas.selection_changed.emit(self.canvas.selection_shape is not None)
+            self._lasso_path = None
         super().mouseReleaseEvent(event, doc_pos)

--- a/portal/tools/selectrectangletool.py
+++ b/portal/tools/selectrectangletool.py
@@ -20,7 +20,7 @@ class SelectRectangleTool(BaseSelectTool):
             return
         clamped_start = self._clamp_to_document(doc_pos)
         self.start_point = clamped_start
-        self.canvas._update_selection_and_emit_size(QPainterPath(clamped_start))
+        self._preview_selection_path(QPainterPath(clamped_start))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
         if not self.moving_selection:
@@ -47,7 +47,7 @@ class SelectRectangleTool(BaseSelectTool):
                 doc_rect = QRect(0, 0, size.width(), size.height())
                 rect = rect.intersected(doc_rect)
             qpp.addRect(rect)
-            self.canvas._update_selection_and_emit_size(qpp)
+            self._preview_selection_path(qpp)
         super().mouseMoveEvent(event, doc_pos)
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):


### PR DESCRIPTION
## Summary
- add support for additive and subtractive selection modes controlled by Shift and Alt in the base selection tool
- update rectangular, circular, and lasso selection tools to preview combined selections while dragging
- extend selection tool tests to cover the new modifier behaviour and adjust expectations for lasso paths

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cc14bcd4dc8321b8352cec73a2b4d2