### PR TITLE
Add frame insert and delete operations to timeline

### DIFF
--- a/portal/commands/timeline_commands.py
+++ b/portal/commands/timeline_commands.py
@@ -49,6 +49,30 @@ class RemoveKeyframeCommand(_KeyframeCommand):
         self.document.remove_key_frame(self.frame_index)
 
 
+class InsertFrameCommand(_KeyframeCommand):
+    """Insert a new frame at ``frame_index``."""
+
+    def __init__(self, document: Document, frame_index: int):
+        super().__init__(document)
+        self.frame_index = frame_index
+
+    def execute(self) -> None:
+        self._capture_before()
+        self.document.insert_frame(self.frame_index)
+
+
+class DeleteFrameCommand(_KeyframeCommand):
+    """Delete the frame at ``frame_index`` if allowed."""
+
+    def __init__(self, document: Document, frame_index: int):
+        super().__init__(document)
+        self.frame_index = frame_index
+
+    def execute(self) -> None:
+        self._capture_before()
+        self.document.remove_frame(self.frame_index)
+
+
 class DuplicateKeyframeCommand(_KeyframeCommand):
     """Duplicate an existing keyframe to another frame index."""
 

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -139,6 +139,12 @@ class App(QObject):
     ) -> Optional[int]:
         return self.document_controller.duplicate_keyframe(source_frame, target_frame)
 
+    def insert_frame(self, frame_index: int) -> None:
+        self.document_controller.insert_frame(frame_index)
+
+    def delete_frame(self, frame_index: int) -> None:
+        self.document_controller.delete_frame(frame_index)
+
     def copy_keyframe(self, frame_index: int) -> bool:
         return self.document_controller.copy_keyframe(frame_index)
 

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -71,6 +71,11 @@ class Document:
         self._notify_layer_manager_changed()
         return frame
 
+    def insert_frame(self, index: int):
+        frame = self.frame_manager.insert_frame(index)
+        self.select_frame(index)
+        return frame
+
     def remove_frame(self, index: int):
         self.frame_manager.remove_frame(index)
         self._notify_layer_manager_changed()

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -18,7 +18,9 @@ from portal.core.command import (
 from portal.commands.layer_commands import RemoveBackgroundCommand
 from portal.commands.timeline_commands import (
     AddKeyframeCommand,
+    DeleteFrameCommand,
     DuplicateKeyframeCommand,
+    InsertFrameCommand,
     PasteKeyframeCommand,
     RemoveKeyframeCommand,
 )
@@ -177,6 +179,28 @@ class DocumentController(QObject):
         command = DuplicateKeyframeCommand(document, source_frame, target_frame)
         self.execute_command(command)
         return command.created_frame
+
+    def insert_frame(self, frame_index: int) -> None:
+        document = self.document
+        if document is None:
+            return
+        if frame_index < 0:
+            frame_index = 0
+        command = InsertFrameCommand(document, frame_index)
+        self.execute_command(command)
+
+    def delete_frame(self, frame_index: int) -> None:
+        document = self.document
+        if document is None:
+            return
+        frame_manager = document.frame_manager
+        frame_count = len(frame_manager.frames)
+        if frame_count <= 1:
+            return
+        if not (0 <= frame_index < frame_count):
+            return
+        command = DeleteFrameCommand(document, frame_index)
+        self.execute_command(command)
 
     def has_copied_keyframe(self) -> bool:
         return self._copied_key_state is not None

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -171,6 +171,12 @@ class MainWindow(QMainWindow):
         self.timeline_widget.key_remove_requested.connect(self.on_timeline_remove_key)
         self.timeline_widget.key_copy_requested.connect(self.on_timeline_copy_key)
         self.timeline_widget.key_paste_requested.connect(self.on_timeline_paste_key)
+        self.timeline_widget.frame_insert_requested.connect(
+            self.on_timeline_insert_frame
+        )
+        self.timeline_widget.frame_delete_requested.connect(
+            self.on_timeline_delete_frame
+        )
 
         self.animation_player.frame_changed.connect(self.timeline_widget.set_current_frame)
         self.animation_player.playing_changed.connect(self._on_player_state_changed)
@@ -462,6 +468,7 @@ class MainWindow(QMainWindow):
         frame_manager = getattr(document, "frame_manager", None) if document else None
         if not document or frame_manager is None:
             self._update_timeline_layer_label(None)
+            self.timeline_widget.set_document_frame_count(0)
             timeline_blocker = QSignalBlocker(self.timeline_widget)
             try:
                 self.timeline_widget.set_total_frames(max(0, playback_total - 1))
@@ -486,6 +493,7 @@ class MainWindow(QMainWindow):
         self._update_timeline_layer_label(layer_name)
 
         frame_count = len(frame_manager.frames)
+        self.timeline_widget.set_document_frame_count(frame_count)
         doc_max_index = max(0, frame_count - 1) if frame_count else 0
         current_frame = frame_manager.active_frame_index
         if current_frame < 0 and frame_count:
@@ -549,6 +557,14 @@ class MainWindow(QMainWindow):
         self.timeline_widget.set_has_copied_key(self.app.has_copied_keyframe())
         if pasted:
             self.timeline_widget.set_current_frame(frame)
+
+    @Slot(int)
+    def on_timeline_insert_frame(self, frame: int) -> None:
+        self.app.insert_frame(frame + 1)
+
+    @Slot(int)
+    def on_timeline_delete_frame(self, frame: int) -> None:
+        self.app.delete_frame(frame)
 
     @Slot(int)
     def on_timeline_frame_changed(self, frame: int) -> None:


### PR DESCRIPTION
## Summary
- add context menu actions to insert and delete frames from the animation timeline
- implement frame-manager support and commands so keyframes shift when frames are inserted or removed
- update application wiring and tests to cover the new frame operations

## Testing
- python -m compileall portal/ui/animation_timeline_widget.py portal/core/frame_manager.py portal/core/document.py portal/core/document_controller.py portal/core/app.py portal/ui/ui.py portal/commands/timeline_commands.py tests/test_frames.py

------
https://chatgpt.com/codex/tasks/task_e_68cc330e476083219131a24fea71f523