### PR TITLE
Allow zooming out below 100 percent

### DIFF
--- a/portal/commands/canvas_input_handler.py
+++ b/portal/commands/canvas_input_handler.py
@@ -139,7 +139,9 @@ class CanvasInputHandler:
             self.canvas.zoom /= 1.25
 
         # Clamp zoom level
-        self.canvas.zoom = max(1, min(self.canvas.zoom, 20.0))
+        min_zoom = getattr(self.canvas, "min_zoom", 0.05)
+        max_zoom = getattr(self.canvas, "max_zoom", 20.0)
+        self.canvas.zoom = max(min_zoom, min(self.canvas.zoom, max_zoom))
 
         # Adjust pan to keep doc_pos_before_zoom at the same mouse_pos
         doc_width_scaled = self.canvas._document_size.width() * self.canvas.zoom

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -49,6 +49,8 @@ class Canvas(QWidget):
         self.x_offset = 0
         self.y_offset = 0
         self.zoom = 1.0
+        self.min_zoom = 0.05
+        self.max_zoom = 20.0
         self.last_point = QPoint()
         self.start_point = QPoint()
         self.temp_image = None
@@ -605,6 +607,7 @@ class Canvas(QWidget):
         zoom_x = (0.8 * canvas_width) / doc_width
         zoom_y = (0.8 * canvas_height) / doc_height
         self.zoom = min(zoom_x, zoom_y)
+        self.min_zoom = min(self.min_zoom, self.zoom)
         self.zoom_changed.emit(self.zoom)
         self.update()
 


### PR DESCRIPTION
## Summary
- add configurable min/max zoom bounds to the canvas
- relax zoom clamping so the mouse wheel can zoom below 100%
- preserve very small initial zoom levels as the minimum so huge canvases stay viewable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc385ee9b88321888be288aae22be8