### PR TITLE
Refine scale tool overlay to match crop gizmo

### DIFF
--- a/portal/tools/scaletool.py
+++ b/portal/tools/scaletool.py
@@ -1,6 +1,6 @@
 import math
 
-from PySide6.QtCore import Qt, QPoint, QPointF, QRectF, Signal
+from PySide6.QtCore import Qt, QPoint, QPointF, QRect, QRectF, Signal
 from PySide6.QtGui import (
     QColor,
     QCursor,
@@ -30,19 +30,36 @@ class ScaleTool(BaseTool):
         super().__init__(canvas)
         self.cursor = QCursor(Qt.ArrowCursor)
         self.scale_factor = 1.0
-        self.is_hovering_handle = False
-        self.is_hovering_center = False
         self.drag_mode: str | None = None
         self.original_image: QImage | None = None
         self.pivot_doc = QPoint(0, 0)
         self.original_selection_shape: QPainterPath | None = None
         self.selection_source_image: QImage | None = None
-        self.base_handle_distance = 80.0
+        self._hover_handle: str | None = None
+        self._active_handle: str | None = None
+        self._hover_pivot = False
+        self._handle_size = 14.0
+        self._pivot_radius = 10.0
+        self._bounds_dirty = True
+        self._base_edge_rect_doc: QRectF | None = None
+        self._scaled_edge_rect_doc: QRectF | None = None
+        self._drag_base_edge_rect_doc: QRectF | None = None
+        self._drag_initial_axis_distance: float | None = None
+        self._drag_axis_direction: int | None = None
 
     # ------------------------------------------------------------------
     def activate(self):
         self.scale_factor = 1.0
         self.scale_changed.emit(self.scale_factor)
+        self.drag_mode = None
+        self._hover_handle = None
+        self._active_handle = None
+        self._hover_pivot = False
+        self._drag_base_edge_rect_doc = None
+        self._drag_initial_axis_distance = None
+        self._drag_axis_direction = None
+        self._bounds_dirty = True
+        self._refresh_base_rect()
         self.pivot_doc = self._calculate_default_pivot_doc()
 
     # ------------------------------------------------------------------
@@ -71,11 +88,26 @@ class ScaleTool(BaseTool):
         self.scale_factor = 1.0
         self.scale_changed.emit(self.scale_factor)
         self.drag_mode = None
+        self._hover_handle = None
+        self._active_handle = None
+        self._hover_pivot = False
+        self._drag_base_edge_rect_doc = None
+        self._drag_initial_axis_distance = None
+        self._drag_axis_direction = None
+        self._bounds_dirty = True
 
     # ------------------------------------------------------------------
     def _calculate_default_pivot_doc(self) -> QPoint:
-        if self.canvas.selection_shape:
-            return self.canvas.selection_shape.boundingRect().center().toPoint()
+        selection_shape = getattr(self.canvas, "selection_shape", None)
+        if selection_shape:
+            rect = selection_shape.boundingRect().toAlignedRect()
+            if rect.isValid() and rect.width() > 0 and rect.height() > 0:
+                edge_rect = QRectF(rect.left(), rect.top(), rect.width(), rect.height())
+                return edge_rect.center().toPoint()
+
+        self._ensure_base_rect()
+        if self._base_edge_rect_doc is not None and not self._base_edge_rect_doc.isEmpty():
+            return self._base_edge_rect_doc.center().toPoint()
 
         layer_manager = self._get_active_layer_manager()
         if layer_manager and layer_manager.active_layer:
@@ -88,109 +120,88 @@ class ScaleTool(BaseTool):
         return self.pivot_doc
 
     # ------------------------------------------------------------------
-    def _get_center(self) -> QPointF:
-        return QPointF(self.canvas.get_canvas_coords(self.pivot_doc))
-
-    # ------------------------------------------------------------------
-    def _get_handle_pos(self) -> QPointF:
-        center = self._get_center()
-        distance = max(24.0, self.base_handle_distance * self.scale_factor)
-        return QPointF(center.x() + distance, center.y())
-
-    # ------------------------------------------------------------------
     def mousePressEvent(self, event, doc_pos):
-        if self.is_hovering_handle:
-            self.drag_mode = "scale"
-            layer_manager = self._get_active_layer_manager()
-            if layer_manager is None:
-                return
+        if event.button() != Qt.LeftButton:
+            return
 
-            active_layer = layer_manager.active_layer
-            if active_layer is None:
-                return
+        self._ensure_base_rect()
 
-            self.original_image = active_layer.image.copy()
-            self.canvas.temp_image_replaces_active_layer = True
-            self.original_selection_shape = None
-            self.selection_source_image = None
+        canvas_pos = QPointF(event.position())
+        handle = self._hit_test_handles(canvas_pos)
 
-            if self.canvas.selection_shape:
-                self.original_selection_shape = QPainterPath(self.canvas.selection_shape)
-                self.selection_source_image = QImage(
-                    self.original_image.size(),
-                    self.original_image.format(),
-                )
-                self.selection_source_image.fill(Qt.transparent)
+        if handle is not None:
+            if self._start_scale_drag(handle):
+                self._update_cursor()
+            return
 
-                selection_painter = QPainter(self.selection_source_image)
-                selection_painter.setRenderHint(QPainter.Antialiasing, False)
-                selection_painter.setRenderHint(QPainter.SmoothPixmapTransform, False)
-                selection_painter.setClipPath(self.original_selection_shape)
-                selection_painter.drawImage(0, 0, self.original_image)
-                selection_painter.end()
-
-        elif self.is_hovering_center:
+        if self._hit_test_pivot(canvas_pos):
             self.drag_mode = "pivot"
+            self._hover_pivot = True
+            self._active_handle = None
+            self._hover_handle = None
+            self._update_cursor()
 
     # ------------------------------------------------------------------
     def mouseHoverEvent(self, event, doc_pos):
-        canvas_pos = QPointF(event.pos())
-        handle_pos = self._get_handle_pos()
-        center_pos = self._get_center()
+        if self.drag_mode == "pivot" or self._active_handle is not None:
+            return
 
-        distance_handle = math.hypot(
-            canvas_pos.x() - handle_pos.x(),
-            canvas_pos.y() - handle_pos.y(),
-        )
-        distance_center = math.hypot(
-            canvas_pos.x() - center_pos.x(),
-            canvas_pos.y() - center_pos.y(),
-        )
+        self._ensure_base_rect()
 
-        new_hover_handle = distance_handle <= 6
-        new_hover_center = distance_center <= 10
+        canvas_pos = QPointF(event.position())
+        handle = self._hit_test_handles(canvas_pos)
+        pivot_hover = False if handle is not None else self._hit_test_pivot(canvas_pos)
 
-        if (
-            self.is_hovering_handle != new_hover_handle
-            or self.is_hovering_center != new_hover_center
-        ):
-            self.is_hovering_handle = new_hover_handle
-            self.is_hovering_center = new_hover_center
-            self.canvas.repaint()
+        if handle != self._hover_handle or pivot_hover != self._hover_pivot:
+            self._hover_handle = handle
+            self._hover_pivot = pivot_hover
+            self._update_cursor()
+            self.canvas.update()
 
     # ------------------------------------------------------------------
     def mouseMoveEvent(self, event, doc_pos):
-        if self.drag_mode == "scale":
-            center = self._get_center()
-            canvas_pos = QPointF(event.pos())
-
-            distance = math.hypot(
-                canvas_pos.x() - center.x(),
-                canvas_pos.y() - center.y(),
-            )
-            distance = max(8.0, distance)
-            scale = distance / self.base_handle_distance
-            scale = max(0.125, scale)
+        if self.drag_mode == "scale" and self._active_handle is not None:
+            new_scale = self._compute_scale_from_handle(event)
+            if new_scale is None:
+                return
 
             if event.modifiers() & Qt.ShiftModifier:
                 snap_increment = 0.125
-                scale = round(scale / snap_increment) * snap_increment
+                new_scale = round(new_scale / snap_increment) * snap_increment
 
-            if abs(scale - self.scale_factor) >= 1e-3:
-                self.scale_factor = scale
+            new_scale = max(0.125, new_scale)
+
+            if abs(new_scale - self.scale_factor) >= 1e-3:
+                self.scale_factor = new_scale
                 self.scale_changed.emit(self.scale_factor)
+                self._update_scaled_rect_from_current_scale()
                 self._update_preview_image()
+            else:
+                self._update_scaled_rect_from_current_scale()
 
             self.canvas.update()
 
         elif self.drag_mode == "pivot":
             self.pivot_doc = doc_pos
+            self._hover_pivot = True
+            self._update_cursor()
             self.canvas.update()
 
     # ------------------------------------------------------------------
     def mouseReleaseEvent(self, event, doc_pos):
+        if event.button() != Qt.LeftButton:
+            return
+
+        if self.drag_mode == "pivot":
+            self.drag_mode = None
+            self._hover_pivot = False
+            self._update_cursor()
+            return
+
         if self.drag_mode != "scale":
             self.drag_mode = None
+            self._active_handle = None
+            self._update_cursor()
             return
 
         self.canvas.temp_image = None
@@ -244,6 +255,15 @@ class ScaleTool(BaseTool):
         self.scale_factor = 1.0
         self.scale_changed.emit(self.scale_factor)
         self.drag_mode = None
+        self._active_handle = None
+        self._hover_handle = None
+        self._hover_pivot = False
+        self._drag_base_edge_rect_doc = None
+        self._drag_initial_axis_distance = None
+        self._drag_axis_direction = None
+        self._scaled_edge_rect_doc = None
+        self._bounds_dirty = True
+        self._update_cursor()
         self.canvas.update()
 
     # ------------------------------------------------------------------
@@ -279,6 +299,8 @@ class ScaleTool(BaseTool):
                 image_to_modify, source_image, transform
             ):
                 self.canvas.temp_image = self.original_image.copy()
+                if self._drag_base_edge_rect_doc is not None:
+                    self._scaled_edge_rect_doc = QRectF(self._drag_base_edge_rect_doc)
                 return
 
             scaled_shape = transform.map(self.original_selection_shape)
@@ -294,6 +316,8 @@ class ScaleTool(BaseTool):
                 image_to_modify, self.original_image, transform
             ):
                 self.canvas.temp_image = self.original_image.copy()
+                if self._drag_base_edge_rect_doc is not None:
+                    self._scaled_edge_rect_doc = QRectF(self._drag_base_edge_rect_doc)
                 return
 
         self.canvas.temp_image = image_to_modify
@@ -301,30 +325,395 @@ class ScaleTool(BaseTool):
     # ------------------------------------------------------------------
     def draw_overlay(self, painter):
         painter.save()
+        painter.setRenderHint(QPainter.Antialiasing, False)
 
-        center = self._get_center()
-        handle_pos = self._get_handle_pos()
+        _, overlay_rect, handle_rects = self._overlay_geometry()
 
         base_color = QColor("#0c7bdc")
-        hover_color = base_color.lighter(120)
+        hover_color = base_color.lighter(130)
+        active_color = QColor("#f5c156")
 
-        color_handle = hover_color if self.is_hovering_handle else base_color
-        color_center = hover_color if self.is_hovering_center else base_color
+        if overlay_rect is not None:
+            border_pen = QPen(base_color)
+            border_pen.setWidth(1)
+            border_pen.setCosmetic(True)
+            painter.setPen(border_pen)
+            painter.setBrush(Qt.NoBrush)
+            painter.drawRect(overlay_rect)
 
-        painter.setPen(QPen(color_center, 4))
+            handle_pen = QPen(base_color.darker(150))
+            handle_pen.setWidth(1)
+            handle_pen.setCosmetic(True)
+            painter.setPen(handle_pen)
+
+            for name, rect in handle_rects.items():
+                if name == self._active_handle:
+                    brush = active_color
+                elif name == self._hover_handle:
+                    brush = hover_color
+                else:
+                    brush = base_color
+                painter.setBrush(brush)
+                painter.drawRect(rect)
+
+        pivot_point = self._doc_to_canvas_point(QPointF(self.pivot_doc))
+        pivot_color = (
+            hover_color if self._hover_pivot or self.drag_mode == "pivot" else base_color
+        )
+
+        painter.setPen(QPen(pivot_color, 2))
         painter.setBrush(Qt.NoBrush)
-        painter.drawEllipse(center, 10, 10)
+        painter.drawEllipse(pivot_point, self._pivot_radius, self._pivot_radius)
 
-        painter.setPen(QPen(color_handle, 4))
-        painter.drawLine(center, handle_pos)
-
-        painter.setBrush(color_handle)
+        painter.setBrush(pivot_color)
         painter.setPen(Qt.NoPen)
-        painter.drawEllipse(handle_pos, 6, 6)
+        painter.drawEllipse(pivot_point, 3, 3)
 
-        text_rect = QRectF(center.x() - 40, center.y() - 46, 80, 20)
+        text_width = 72
+        text_height = 20
+        if overlay_rect is not None:
+            text_rect = QRectF(
+                overlay_rect.center().x() - text_width / 2,
+                overlay_rect.top() - text_height - 6,
+                text_width,
+                text_height,
+            )
+        else:
+            text_rect = QRectF(
+                pivot_point.x() - text_width / 2,
+                pivot_point.y() - self._pivot_radius - text_height - 6,
+                text_width,
+                text_height,
+            )
+
+        painter.setBrush(QColor(0, 0, 0, 160))
+        painter.setPen(Qt.NoPen)
+        painter.drawRoundedRect(text_rect, 4, 4)
+
         painter.setPen(QPen(QColor("#ffffff")))
         painter.drawText(text_rect, Qt.AlignCenter, f"{self.scale_factor:.2f}x")
 
         painter.restore()
+
+    # ------------------------------------------------------------------
+    def _start_scale_drag(self, handle: str) -> bool:
+        layer_manager = self._get_active_layer_manager()
+        if layer_manager is None or layer_manager.active_layer is None:
+            return False
+
+        base_rect = self._base_edge_rect_doc
+        if base_rect is None or base_rect.isEmpty():
+            return False
+
+        handle_positions = self._handle_positions_for_edge_rect(base_rect)
+        handle_pos = handle_positions.get(handle)
+        if handle_pos is None:
+            return False
+
+        pivot_point = QPointF(self._get_scale_center_doc())
+        axis_distance = (
+            handle_pos.x() - pivot_point.x()
+            if handle in ("left", "right")
+            else handle_pos.y() - pivot_point.y()
+        )
+
+        if math.isclose(axis_distance, 0.0, abs_tol=1e-6):
+            return False
+
+        active_layer = layer_manager.active_layer
+        self.original_image = active_layer.image.copy()
+        self.canvas.temp_image_replaces_active_layer = True
+        self.original_selection_shape = None
+        self.selection_source_image = None
+
+        if self.canvas.selection_shape:
+            self.original_selection_shape = QPainterPath(self.canvas.selection_shape)
+            self.selection_source_image = QImage(
+                self.original_image.size(),
+                self.original_image.format(),
+            )
+            self.selection_source_image.fill(Qt.transparent)
+
+            selection_painter = QPainter(self.selection_source_image)
+            selection_painter.setRenderHint(QPainter.Antialiasing, False)
+            selection_painter.setRenderHint(QPainter.SmoothPixmapTransform, False)
+            selection_painter.setClipPath(self.original_selection_shape)
+            selection_painter.drawImage(0, 0, self.original_image)
+            selection_painter.end()
+
+        self.drag_mode = "scale"
+        self._active_handle = handle
+        self._hover_handle = handle
+        self._drag_base_edge_rect_doc = QRectF(base_rect)
+        self._drag_initial_axis_distance = axis_distance
+        self._drag_axis_direction = 1 if axis_distance >= 0 else -1
+        self._scaled_edge_rect_doc = QRectF(self._drag_base_edge_rect_doc)
+        return True
+
+    # ------------------------------------------------------------------
+    def _compute_scale_from_handle(self, event) -> float | None:
+        if self._active_handle is None or self._drag_initial_axis_distance is None:
+            return None
+
+        canvas_pos = QPointF(event.position())
+        doc_point = self._canvas_to_doc_point(canvas_pos)
+        pivot_point = QPointF(self._get_scale_center_doc())
+
+        if self._active_handle in ("left", "right"):
+            raw_distance = doc_point.x() - pivot_point.x()
+        else:
+            raw_distance = doc_point.y() - pivot_point.y()
+
+        direction = self._drag_axis_direction or 1
+        aligned_distance = raw_distance * direction
+        if aligned_distance < 0:
+            aligned_distance = 0.0
+
+        if aligned_distance <= 1e-4:
+            return 0.125
+
+        scale = aligned_distance / abs(self._drag_initial_axis_distance)
+        return max(0.125, scale)
+
+    # ------------------------------------------------------------------
+    def _current_edge_rect_doc(self) -> QRectF | None:
+        selection_shape = getattr(self.canvas, "selection_shape", None)
+        if selection_shape:
+            rect = selection_shape.boundingRect().toAlignedRect()
+            if rect.isValid() and rect.width() > 0 and rect.height() > 0:
+                return QRectF(rect.left(), rect.top(), rect.width(), rect.height())
+
+        if self._scaled_edge_rect_doc is not None and not self._scaled_edge_rect_doc.isEmpty():
+            return QRectF(self._scaled_edge_rect_doc)
+
+        self._ensure_base_rect()
+        if self._base_edge_rect_doc is not None and not self._base_edge_rect_doc.isEmpty():
+            return QRectF(self._base_edge_rect_doc)
+
+        return None
+
+    # ------------------------------------------------------------------
+    def _refresh_base_rect(self):
+        rect = self._calculate_target_edge_rect_doc()
+        if rect is None:
+            self._base_edge_rect_doc = None
+            self._scaled_edge_rect_doc = None
+        else:
+            self._base_edge_rect_doc = QRectF(rect)
+            self._scaled_edge_rect_doc = QRectF(rect)
+        self._bounds_dirty = False
+
+    # ------------------------------------------------------------------
+    def _ensure_base_rect(self):
+        if self._bounds_dirty:
+            self._refresh_base_rect()
+
+    # ------------------------------------------------------------------
+    def _calculate_target_edge_rect_doc(self) -> QRectF | None:
+        selection_shape = getattr(self.canvas, "selection_shape", None)
+        if selection_shape:
+            rect = selection_shape.boundingRect().toAlignedRect()
+            if rect.isValid() and rect.width() > 0 and rect.height() > 0:
+                return QRectF(rect.left(), rect.top(), rect.width(), rect.height())
+
+        layer_manager = self._get_active_layer_manager()
+        if layer_manager and layer_manager.active_layer is not None:
+            image = layer_manager.active_layer.image
+            if image is not None and not image.isNull():
+                bounds = self._find_non_transparent_bounds(image)
+                if bounds is None:
+                    bounds = image.rect()
+                if bounds.isValid() and bounds.width() > 0 and bounds.height() > 0:
+                    return QRectF(bounds.left(), bounds.top(), bounds.width(), bounds.height())
+
+        document = getattr(self.canvas, "document", None)
+        if document is not None:
+            width = getattr(document, "width", None)
+            height = getattr(document, "height", None)
+            if width is not None and height is not None:
+                width_int = max(1, int(width))
+                height_int = max(1, int(height))
+                return QRectF(0, 0, width_int, height_int)
+
+        return None
+
+    # ------------------------------------------------------------------
+    def _find_non_transparent_bounds(self, image: QImage) -> QRect | None:
+        width = image.width()
+        height = image.height()
+        if width <= 0 or height <= 0:
+            return None
+
+        left = width
+        right = -1
+        top = height
+        bottom = -1
+
+        for y in range(height):
+            row_left = None
+            row_right = None
+
+            for x in range(width):
+                if image.pixelColor(x, y).alpha() > 0:
+                    row_left = x
+                    break
+
+            if row_left is None:
+                continue
+
+            for x in range(width - 1, -1, -1):
+                if image.pixelColor(x, y).alpha() > 0:
+                    row_right = x
+                    break
+
+            if row_right is None:
+                continue
+
+            if row_left < left:
+                left = row_left
+            if row_right > right:
+                right = row_right
+            if top == height:
+                top = y
+            bottom = y
+
+        if right < left or bottom < top:
+            return None
+
+        return QRect(left, top, right - left + 1, bottom - top + 1)
+
+    # ------------------------------------------------------------------
+    def _update_scaled_rect_from_current_scale(self):
+        base_rect = self._drag_base_edge_rect_doc or self._base_edge_rect_doc
+        if base_rect is None or base_rect.isEmpty():
+            self._scaled_edge_rect_doc = None
+            return
+
+        if math.isclose(self.scale_factor, 1.0, abs_tol=1e-4):
+            self._scaled_edge_rect_doc = QRectF(base_rect)
+        else:
+            self._scaled_edge_rect_doc = self._scale_edge_rect(base_rect, self.scale_factor)
+
+    # ------------------------------------------------------------------
+    def _scale_edge_rect(self, rect: QRectF, factor: float) -> QRectF:
+        center = QPointF(self._get_scale_center_doc())
+        transform = (
+            QTransform()
+            .translate(center.x(), center.y())
+            .scale(factor, factor)
+            .translate(-center.x(), -center.y())
+        )
+        top_left = transform.map(rect.topLeft())
+        bottom_right = transform.map(rect.bottomRight())
+        return QRectF(top_left, bottom_right).normalized()
+
+    # ------------------------------------------------------------------
+    def _doc_to_canvas_point(self, point: QPointF) -> QPointF:
+        zoom = self.canvas.zoom if self.canvas.zoom != 0 else 1.0
+        doc_width_scaled = self.canvas._document_size.width() * zoom
+        doc_height_scaled = self.canvas._document_size.height() * zoom
+        canvas_width = self.canvas.width()
+        canvas_height = self.canvas.height()
+        x_offset = (canvas_width - doc_width_scaled) / 2 + self.canvas.x_offset
+        y_offset = (canvas_height - doc_height_scaled) / 2 + self.canvas.y_offset
+        return QPointF(point.x() * zoom + x_offset, point.y() * zoom + y_offset)
+
+    # ------------------------------------------------------------------
+    def _canvas_to_doc_point(self, point: QPointF) -> QPointF:
+        zoom = self.canvas.zoom if self.canvas.zoom != 0 else 1.0
+        doc_width_scaled = self.canvas._document_size.width() * zoom
+        doc_height_scaled = self.canvas._document_size.height() * zoom
+        canvas_width = self.canvas.width()
+        canvas_height = self.canvas.height()
+        x_offset = (canvas_width - doc_width_scaled) / 2 + self.canvas.x_offset
+        y_offset = (canvas_height - doc_height_scaled) / 2 + self.canvas.y_offset
+        doc_x = (point.x() - x_offset) / zoom
+        doc_y = (point.y() - y_offset) / zoom
+        return QPointF(doc_x, doc_y)
+
+    # ------------------------------------------------------------------
+    def _edge_rect_doc_to_canvas(self, rect: QRectF) -> QRectF:
+        top_left = self._doc_to_canvas_point(rect.topLeft())
+        bottom_right = self._doc_to_canvas_point(rect.bottomRight())
+        return QRectF(top_left, bottom_right).normalized()
+
+    # ------------------------------------------------------------------
+    def _handle_positions_for_edge_rect(self, rect: QRectF) -> dict[str, QPointF]:
+        center = rect.center()
+        return {
+            "left": QPointF(rect.left(), center.y()),
+            "right": QPointF(rect.right(), center.y()),
+            "top": QPointF(center.x(), rect.top()),
+            "bottom": QPointF(center.x(), rect.bottom()),
+        }
+
+    # ------------------------------------------------------------------
+    def _overlay_geometry(self):
+        rect_doc = self._current_edge_rect_doc()
+        if rect_doc is None or rect_doc.isEmpty():
+            return None, None, {}
+
+        rect_canvas = self._edge_rect_doc_to_canvas(rect_doc)
+        handle_rects = self._handle_rects_for_canvas_rect(rect_canvas)
+        return rect_doc, rect_canvas, handle_rects
+
+    # ------------------------------------------------------------------
+    def _handle_rects_for_canvas_rect(self, rect: QRectF) -> dict[str, QRectF]:
+        center = rect.center()
+        positions = {
+            "left": QPointF(rect.left(), center.y()),
+            "right": QPointF(rect.right(), center.y()),
+            "top": QPointF(center.x(), rect.top()),
+            "bottom": QPointF(center.x(), rect.bottom()),
+        }
+
+        half = self._handle_size / 2.0
+        handle_rects: dict[str, QRectF] = {}
+        for name, point in positions.items():
+            handle_rects[name] = QRectF(
+                point.x() - half,
+                point.y() - half,
+                self._handle_size,
+                self._handle_size,
+            )
+        return handle_rects
+
+    # ------------------------------------------------------------------
+    def _hit_test_handles(self, canvas_pos: QPointF) -> str | None:
+        _, _, handle_rects = self._overlay_geometry()
+        for name, rect in handle_rects.items():
+            if rect.contains(canvas_pos):
+                return name
+        return None
+
+    # ------------------------------------------------------------------
+    def _hit_test_pivot(self, canvas_pos: QPointF) -> bool:
+        pivot_point = self._doc_to_canvas_point(QPointF(self.pivot_doc))
+        distance = math.hypot(
+            canvas_pos.x() - pivot_point.x(),
+            canvas_pos.y() - pivot_point.y(),
+        )
+        return distance <= self._pivot_radius
+
+    # ------------------------------------------------------------------
+    def _cursor_for_handle(self, handle: str | None):
+        if handle in ("left", "right"):
+            return Qt.SizeHorCursor
+        if handle in ("top", "bottom"):
+            return Qt.SizeVerCursor
+        return None
+
+    # ------------------------------------------------------------------
+    def _update_cursor(self):
+        handle = self._active_handle or self._hover_handle
+        cursor = self._cursor_for_handle(handle)
+        if cursor is not None:
+            self.canvas.setCursor(cursor)
+            return
+
+        if self.drag_mode == "pivot" or self._hover_pivot:
+            self.canvas.setCursor(Qt.SizeAllCursor)
+            return
+
+        self.canvas.setCursor(self.cursor)
 


### PR DESCRIPTION
## Summary
- replace the scale tool's radial gizmo with a rectangular overlay that mirrors the crop tool
- add interactive side handles, pivot highlighting, and bounding-box calculations for selections or opaque content
- compute non-transparent bounds lazily so overlay stays in sync after scaling or selection updates

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc681e0ba88321bd9599ee62aa7d8a