### PR TITLE
Add frame scope to flip command

### DIFF
--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -174,9 +174,9 @@ class App(QObject):
     def select_none(self):
         self.select_none_triggered.emit()
 
-    @Slot(bool, bool, bool)
-    def flip(self, horizontal, vertical, all_layers):
-        self.document_controller.flip(horizontal, vertical, all_layers)
+    @Slot(bool, bool, object)
+    def flip(self, horizontal, vertical, scope):
+        self.document_controller.flip(horizontal, vertical, scope)
 
     @Slot()
     def invert_selection(self):

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -10,6 +10,7 @@ from portal.core.undo import UndoManager
 from portal.core.drawing_context import DrawingContext
 from portal.core.command import (
     FlipCommand,
+    FlipScope,
     ResizeCommand,
     CropCommand,
     AddLayerCommand,
@@ -173,10 +174,23 @@ class DocumentController(QObject):
         self.undo_stack_changed.emit()
         self.document_changed.emit()
 
-    @Slot(bool, bool, bool)
-    def flip(self, horizontal, vertical, all_layers):
+    @Slot(bool, bool, object)
+    def flip(self, horizontal, vertical, scope):
         if self.document:
-            command = FlipCommand(self.document, horizontal, vertical, all_layers)
+            if not isinstance(scope, FlipScope):
+                scope_map = {
+                    True: FlipScope.FRAME,
+                    False: FlipScope.LAYER,
+                    "layer": FlipScope.LAYER,
+                    "current_layer": FlipScope.LAYER,
+                    "frame": FlipScope.FRAME,
+                    "current_frame": FlipScope.FRAME,
+                    "document": FlipScope.DOCUMENT,
+                    "whole_document": FlipScope.DOCUMENT,
+                    "all_frames": FlipScope.DOCUMENT,
+                }
+                scope = scope_map.get(scope, FlipScope.LAYER)
+            command = FlipCommand(self.document, horizontal, vertical, scope)
             self.execute_command(command)
 
     def add_keyframe(self, frame_index: int) -> None:

--- a/portal/ui/flip_dialog.py
+++ b/portal/ui/flip_dialog.py
@@ -1,4 +1,14 @@
-from PySide6.QtWidgets import QDialog, QCheckBox, QPushButton, QVBoxLayout, QHBoxLayout, QGroupBox, QRadioButton
+from PySide6.QtWidgets import (
+    QDialog,
+    QCheckBox,
+    QPushButton,
+    QVBoxLayout,
+    QHBoxLayout,
+    QGroupBox,
+    QRadioButton,
+)
+
+from portal.core.command import FlipScope
 
 class FlipDialog(QDialog):
     def __init__(self, parent=None):
@@ -18,10 +28,12 @@ class FlipDialog(QDialog):
         # Scope Radio Buttons
         self.scope_group = QGroupBox("Scope")
         self.current_layer_radio = QRadioButton("Current Layer")
+        self.current_frame_radio = QRadioButton("Current Frame")
         self.whole_document_radio = QRadioButton("Whole Document")
         self.current_layer_radio.setChecked(True)
         scope_layout = QVBoxLayout()
         scope_layout.addWidget(self.current_layer_radio)
+        scope_layout.addWidget(self.current_frame_radio)
         scope_layout.addWidget(self.whole_document_radio)
         self.scope_group.setLayout(scope_layout)
 
@@ -42,8 +54,15 @@ class FlipDialog(QDialog):
         self.setLayout(main_layout)
 
     def get_values(self):
+        if self.whole_document_radio.isChecked():
+            scope = FlipScope.DOCUMENT
+        elif self.current_frame_radio.isChecked():
+            scope = FlipScope.FRAME
+        else:
+            scope = FlipScope.LAYER
+
         return {
             "horizontal": self.horizontal_checkbox.isChecked(),
             "vertical": self.vertical_checkbox.isChecked(),
-            "all_layers": self.whole_document_radio.isChecked()
+            "scope": scope,
         }

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -861,7 +861,7 @@ class MainWindow(QMainWindow):
             dialog = FlipDialog(self)
             if dialog.exec():
                 values = dialog.get_values()
-                self.app.flip(values["horizontal"], values["vertical"], values["all_layers"])
+                self.app.flip(values["horizontal"], values["vertical"], values["scope"])
 
     def apply_grid_settings_from_settings(self):
         self.canvas.set_grid_settings(**self.app.settings_controller.get_grid_settings())


### PR DESCRIPTION
## Summary
- add a FlipScope enum and update FlipCommand to deduplicate flipped layers across frame and document scopes
- plumb the new scope through the document controller, app API, and flip dialog so users can target the current layer, frame, or whole document
- expand unit tests to cover the new frame and document scopes and keep existing behaviour intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5e9a56988321b019475fb0170346