### PR TITLE
Enable dragging and repositioning timeline keys

### DIFF
--- a/portal/commands/timeline_commands.py
+++ b/portal/commands/timeline_commands.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from typing import Iterable, Mapping, Optional
 
 from portal.core.command import Command
 from portal.core.document import Document
@@ -70,6 +70,30 @@ class SetKeyframesCommand(_KeyframeCommand):
     def execute(self) -> None:
         self._capture_before()
         self.document.set_key_frames(self.frames)
+
+
+class MoveKeyframesCommand(_KeyframeCommand):
+    """Move existing keyframes according to ``moves`` mapping."""
+
+    def __init__(self, document: Document, moves: Mapping[int, int]):
+        super().__init__(document)
+        normalized: dict[int, int] = {}
+        for source, target in moves.items():
+            try:
+                source_index = int(source)
+                target_index = int(target)
+            except (TypeError, ValueError):
+                continue
+            if source_index < 0 or target_index < 0:
+                continue
+            normalized[source_index] = target_index
+        self.moves = normalized
+
+    def execute(self) -> None:
+        if not self.moves:
+            return
+        self._capture_before()
+        self.document.move_key_frames(self.moves)
 
 
 class InsertFrameCommand(_KeyframeCommand):

--- a/portal/commands/timeline_commands.py
+++ b/portal/commands/timeline_commands.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Iterable, Optional
 
 from portal.core.command import Command
 from portal.core.document import Document
@@ -47,6 +47,29 @@ class RemoveKeyframeCommand(_KeyframeCommand):
     def execute(self) -> None:
         self._capture_before()
         self.document.remove_key_frame(self.frame_index)
+
+
+class SetKeyframesCommand(_KeyframeCommand):
+    """Replace the active layer's keyframes with ``frames``."""
+
+    def __init__(self, document: Document, frames: Iterable[int]):
+        super().__init__(document)
+        normalized: set[int] = set()
+        for value in frames:
+            try:
+                frame = int(value)
+            except (TypeError, ValueError):
+                continue
+            if frame < 0:
+                continue
+            normalized.add(frame)
+        if not normalized:
+            normalized = {0}
+        self.frames = sorted(normalized)
+
+    def execute(self) -> None:
+        self._capture_before()
+        self.document.set_key_frames(self.frames)
 
 
 class InsertFrameCommand(_KeyframeCommand):

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -141,6 +141,9 @@ class App(QObject):
     def set_keyframes(self, frames: Iterable[int]) -> None:
         self.document_controller.set_keyframes(frames)
 
+    def move_keyframes(self, frames: Iterable[int], delta: int) -> None:
+        self.document_controller.move_keyframes(frames, delta)
+
     def add_keyframe(self, frame_index: int) -> None:
         self.document_controller.add_keyframe(frame_index)
 

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from typing import Iterable, Optional
+
+import os
 
 from PySide6.QtCore import QObject, Signal, Slot
-import os
 
 from portal.core.document_controller import DocumentController, BackgroundRemovalScope
 from portal.core.settings_controller import SettingsController
@@ -136,6 +137,9 @@ class App(QObject):
 
     def ensure_auto_key_for_active_layer(self) -> bool:
         return self.document_controller.ensure_auto_key_for_active_layer()
+
+    def set_keyframes(self, frames: Iterable[int]) -> None:
+        self.document_controller.set_keyframes(frames)
 
     def add_keyframe(self, frame_index: int) -> None:
         self.document_controller.add_keyframe(frame_index)

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -1,6 +1,5 @@
-from typing import Iterable, Optional
-
 import os
+from typing import Iterable, Optional
 
 from PySide6.QtCore import QObject, Signal, Slot
 

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 import io
 import json
 
@@ -119,6 +119,18 @@ class Document:
         if layer is None:
             return False
         changed = self.frame_manager.set_layer_key_frames(layer.uid, frames)
+        if changed:
+            self._notify_layer_manager_changed()
+        return changed
+
+    def move_key_frames(self, moves: Mapping[int, int]) -> bool:
+        layer_manager = self.frame_manager.current_layer_manager
+        if layer_manager is None:
+            return False
+        layer = layer_manager.active_layer
+        if layer is None:
+            return False
+        changed = self.frame_manager.move_layer_keys(layer.uid, moves)
         if changed:
             self._notify_layer_manager_changed()
         return changed

--- a/portal/core/frame_manager.py
+++ b/portal/core/frame_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from bisect import bisect_right
-from typing import Dict, Iterable, List, Optional, Set
+from typing import Dict, Iterable, List, Mapping, Optional, Set
 
 from PySide6.QtGui import QImage
 
@@ -130,6 +130,8 @@ class FrameManager:
             if fallback_index is None:
                 continue
             if not (0 <= fallback_index < len(self.frames)):
+                continue
+            if frame_index < fallback_index:
                 continue
             source_manager = self.frames[fallback_index].layer_manager
             target_manager = frame.layer_manager
@@ -355,6 +357,63 @@ class FrameManager:
         self._rebind_layer_fallbacks(layer_uid)
         return True
 
+    def move_layer_keys(self, layer_uid: int, moves: Mapping[int, int]) -> bool:
+        keys = self.layer_keys.get(layer_uid)
+        if not keys:
+            return False
+        normalized: dict[int, int] = {}
+        for source, target in moves.items():
+            try:
+                source_index = int(source)
+                target_index = int(target)
+            except (TypeError, ValueError):
+                continue
+            if source_index not in keys:
+                continue
+            if target_index < 0:
+                continue
+            self.ensure_frame(target_index)
+            if not (0 <= target_index < len(self.frames)):
+                continue
+            normalized[source_index] = target_index
+        if not normalized:
+            return False
+        if all(source == target for source, target in normalized.items()):
+            return False
+
+        for source, target in normalized.items():
+            if source == target:
+                continue
+            self._clone_layer_state(layer_uid, source, target)
+
+        existing_keys = set(keys)
+        target_positions = set(normalized.values())
+
+        updated_keys = set(existing_keys)
+        for source, target in normalized.items():
+            if source != target:
+                updated_keys.discard(source)
+        for target in target_positions:
+            updated_keys.discard(target)
+        updated_keys.update(target_positions)
+        if not updated_keys and self.frames:
+            updated_keys = {0}
+        if updated_keys == existing_keys:
+            return False
+        self.layer_keys[layer_uid] = updated_keys
+
+        for source, target in normalized.items():
+            if source == target:
+                continue
+            manager = self.frames[source].layer_manager
+            layer = self._find_layer(manager, layer_uid)
+            if layer is not None:
+                layer.clear()
+
+        self._refresh_frame_markers()
+        self._rebind_layer_fallbacks(layer_uid)
+        return True
+
     def add_layer_key(self, layer_uid: int, index: int) -> bool:
         if index < 0:
             return False
@@ -552,7 +611,7 @@ class FrameManager:
         position = bisect_right(sorted_keys, frame_index)
         if position:
             return sorted_keys[position - 1]
-        return sorted_keys[0]
+        return frame_index
 
     def resolve_layer_key_frame_index(
         self, layer_uid: int, frame_index: Optional[int] = None

--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -53,7 +53,7 @@ class AnimationTimelineWidget(QWidget):
     key_paste_requested = Signal(int)
     frame_insert_requested = Signal(int)
     frame_delete_requested = Signal(int)
-    key_move_requested = Signal(list)
+    key_move_requested = Signal(list, int)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -81,6 +81,7 @@ class AnimationTimelineWidget(QWidget):
         self._key_drag_candidate_frame: int | None = None
         self._key_drag_initial_keys: Set[int] = set()
         self._key_drag_other_keys: Set[int] = set()
+        self._key_drag_initial_all_keys: Set[int] = set()
         self._key_drag_start_frame = 0
         self._key_drag_last_offset = 0
         self._key_drag_has_moved = False
@@ -710,6 +711,7 @@ class AnimationTimelineWidget(QWidget):
         self._key_drag_other_keys = {
             key for key in self._keys if key not in self._key_drag_initial_keys
         }
+        self._key_drag_initial_all_keys = set(self._keys)
         self._key_drag_start_frame = frame
         self._key_drag_last_offset = 0
         self._key_drag_has_moved = False
@@ -723,6 +725,7 @@ class AnimationTimelineWidget(QWidget):
         self._key_drag_candidate_modifiers = Qt.NoModifier
         self._key_drag_initial_keys = set()
         self._key_drag_other_keys = set()
+        self._key_drag_initial_all_keys = set()
         self._key_drag_start_frame = 0
         self._key_drag_last_offset = 0
         self._key_drag_has_moved = False
@@ -790,7 +793,9 @@ class AnimationTimelineWidget(QWidget):
             moved_keys = self.keys()
             follow_current = self._key_drag_follow_current_frame
             final_frame = self._current_frame
-            self.key_move_requested.emit(moved_keys)
+            initial_selection = sorted(self._key_drag_initial_keys)
+            if initial_selection and set(moved_keys) != self._key_drag_initial_all_keys:
+                self.key_move_requested.emit(initial_selection, self._key_drag_last_offset)
             if follow_current:
                 self._set_current_frame_internal(final_frame, emit_signal=False)
                 self.current_frame_changed.emit(final_frame)

--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import ceil
 from typing import Iterable, List, Set
 
@@ -34,6 +34,43 @@ class _TimelineLayout:
     scrub_top: float
     scrub_bottom: float
 
+
+@dataclass
+class _KeyDragState:
+    """Runtime information captured while dragging keyed frames."""
+
+    is_dragging: bool = False
+    candidate_frame: int | None = None
+    candidate_modifiers: Qt.KeyboardModifiers = Qt.NoModifier
+    initial_keys: Set[int] = field(default_factory=set)
+    other_keys: Set[int] = field(default_factory=set)
+    all_keys: Set[int] = field(default_factory=set)
+    start_frame: int = 0
+    last_offset: int = 0
+    has_moved: bool = False
+    defer_selection: bool = False
+    follow_current_frame: bool = False
+    start_current_frame: int = 0
+
+    def clear(self) -> None:
+        self.is_dragging = False
+        self.candidate_frame = None
+        self.candidate_modifiers = Qt.NoModifier
+        self.initial_keys.clear()
+        self.other_keys.clear()
+        self.all_keys.clear()
+        self.start_frame = 0
+        self.last_offset = 0
+        self.has_moved = False
+        self.defer_selection = False
+        self.follow_current_frame = False
+        self.start_current_frame = 0
+
+    @property
+    def pending(self) -> bool:
+        """Return True if a drag candidate is waiting to activate."""
+
+        return self.candidate_frame is not None
 
 class AnimationTimelineWidget(QWidget):
     """A minimal animation timeline widget displaying frames and keyed positions.
@@ -77,18 +114,8 @@ class AnimationTimelineWidget(QWidget):
         self._scrub_tolerance = 4.0
         self._key_hit_padding = 4.0
         self._document_frame_count = 1
-        self._is_dragging_keys = False
-        self._key_drag_candidate_frame: int | None = None
-        self._key_drag_initial_keys: Set[int] = set()
-        self._key_drag_other_keys: Set[int] = set()
-        self._key_drag_initial_all_keys: Set[int] = set()
-        self._key_drag_start_frame = 0
-        self._key_drag_last_offset = 0
-        self._key_drag_has_moved = False
-        self._key_drag_defer_selection = False
-        self._key_drag_candidate_modifiers = Qt.NoModifier
-        self._key_drag_follow_current_frame = False
-        self._key_drag_start_current_frame = 0
+        self._drag_state = _KeyDragState()
+        self._drag_state.clear()
 
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.setMinimumHeight(100)
@@ -411,13 +438,13 @@ class AnimationTimelineWidget(QWidget):
             self._is_panning = False
             self._last_pan_x = 0.0
             self.unsetCursor()
-        if self._is_dragging_keys or self._key_drag_candidate_frame is not None:
+        if self._drag_state.is_dragging or self._drag_state.pending:
             if event.buttons() & Qt.LeftButton:
                 frame = self._frame_at_point(event)
                 self._update_key_drag(frame)
                 event.accept()
                 return
-            if not self._is_dragging_keys:
+            if not self._drag_state.is_dragging:
                 self._clear_key_drag_state()
         if not (event.buttons() & Qt.LeftButton):
             self._is_dragging = False
@@ -704,114 +731,95 @@ class AnimationTimelineWidget(QWidget):
         if not initial_selection or frame not in initial_selection:
             self._clear_key_drag_state()
             return
-        self._is_dragging_keys = False
-        self._key_drag_candidate_frame = frame
-        self._key_drag_candidate_modifiers = modifiers
-        self._key_drag_initial_keys = initial_selection
-        self._key_drag_other_keys = {
-            key for key in self._keys if key not in self._key_drag_initial_keys
-        }
-        self._key_drag_initial_all_keys = set(self._keys)
-        self._key_drag_start_frame = frame
-        self._key_drag_last_offset = 0
-        self._key_drag_has_moved = False
-        self._key_drag_defer_selection = defer_selection
-        self._key_drag_follow_current_frame = self._current_frame in initial_selection
-        self._key_drag_start_current_frame = self._current_frame
+        state = self._drag_state
+        state.clear()
+        state.candidate_frame = frame
+        state.candidate_modifiers = modifiers
+        state.initial_keys.update(initial_selection)
+        state.other_keys.update(key for key in self._keys if key not in state.initial_keys)
+        state.all_keys.update(self._keys)
+        state.start_frame = frame
+        state.last_offset = 0
+        state.has_moved = False
+        state.defer_selection = defer_selection
+        state.follow_current_frame = self._current_frame in initial_selection
+        state.start_current_frame = self._current_frame
 
     def _clear_key_drag_state(self) -> None:
-        self._is_dragging_keys = False
-        self._key_drag_candidate_frame = None
-        self._key_drag_candidate_modifiers = Qt.NoModifier
-        self._key_drag_initial_keys = set()
-        self._key_drag_other_keys = set()
-        self._key_drag_initial_all_keys = set()
-        self._key_drag_start_frame = 0
-        self._key_drag_last_offset = 0
-        self._key_drag_has_moved = False
-        self._key_drag_defer_selection = False
-        self._key_drag_follow_current_frame = False
-        self._key_drag_start_current_frame = 0
+        self._drag_state.clear()
 
     def _clamp_key_drag_delta(self, delta: int) -> int:
-        if not self._key_drag_initial_keys:
+        state = self._drag_state
+        if not state.initial_keys:
             return 0
-        min_key = min(self._key_drag_initial_keys)
+        min_key = min(state.initial_keys)
         min_delta = -min_key
-        if delta < min_delta:
-            return min_delta
-        return delta
+        return max(min_delta, delta)
 
     def _update_key_drag(self, frame: int) -> None:
-        if self._key_drag_candidate_frame is None:
+        state = self._drag_state
+        if not state.pending:
             return
-        delta = frame - self._key_drag_start_frame
+        delta = frame - state.start_frame
         clamped_delta = self._clamp_key_drag_delta(delta)
-        if not self._is_dragging_keys and (clamped_delta != 0 or self._key_drag_has_moved):
-            self._is_dragging_keys = True
-        if clamped_delta == self._key_drag_last_offset:
+        if not state.is_dragging and (clamped_delta != 0 or state.has_moved):
+            state.is_dragging = True
+        if clamped_delta == state.last_offset:
             if delta != 0:
-                self._key_drag_has_moved = True
+                state.has_moved = True
             return
         if clamped_delta != 0:
-            self._key_drag_has_moved = True
+            state.has_moved = True
         self._apply_key_drag_delta(clamped_delta)
-        self._key_drag_last_offset = clamped_delta
+        state.last_offset = clamped_delta
 
     def _apply_key_drag_delta(self, delta: int) -> None:
-        if not self._key_drag_initial_keys:
+        state = self._drag_state
+        if not state.initial_keys:
             return
-        shifted_keys = {frame + delta for frame in self._key_drag_initial_keys}
-        shifted_keys = {max(0, frame) for frame in shifted_keys}
-        remaining_keys = {
-            frame for frame in self._key_drag_other_keys if frame not in shifted_keys
-        }
+        shifted_keys = {max(0, frame + delta) for frame in state.initial_keys}
+        remaining_keys = {frame for frame in state.other_keys if frame not in shifted_keys}
         updated_keys = remaining_keys | shifted_keys
         if not updated_keys:
             updated_keys = {0}
-        self._keys = updated_keys
+        if updated_keys != self._keys:
+            self._keys = updated_keys
         self._ensure_base_frame(max(updated_keys))
         anchor = self._selection_anchor
-        if anchor in self._key_drag_initial_keys:
+        if anchor in state.initial_keys:
             anchor = anchor + delta
         self._set_selection(shifted_keys, anchor=anchor, prefer_existing_anchor=True)
-        if self._key_drag_follow_current_frame:
-            target_frame = self._key_drag_start_current_frame + delta
+        if state.follow_current_frame:
+            target_frame = state.start_current_frame + delta
             self._set_current_frame_internal(target_frame, emit_signal=False)
         else:
             self.update()
         self.keys_changed.emit(self.keys())
 
     def _finish_key_drag(self, event: QMouseEvent) -> bool:
-        if (
-            self._key_drag_candidate_frame is None
-            and not self._is_dragging_keys
-            and not self._key_drag_has_moved
-        ):
+        state = self._drag_state
+        if not state.pending and not state.is_dragging and not state.has_moved:
             return False
-        if self._is_dragging_keys or self._key_drag_has_moved:
+        if state.is_dragging or state.has_moved:
             moved_keys = self.keys()
-            follow_current = self._key_drag_follow_current_frame
+            follow_current = state.follow_current_frame
             final_frame = self._current_frame
-            initial_selection = sorted(self._key_drag_initial_keys)
-            if initial_selection and set(moved_keys) != self._key_drag_initial_all_keys:
-                self.key_move_requested.emit(initial_selection, self._key_drag_last_offset)
+            initial_selection = sorted(state.initial_keys)
+            if initial_selection and set(moved_keys) != state.all_keys:
+                self.key_move_requested.emit(initial_selection, state.last_offset)
             if follow_current:
                 self._set_current_frame_internal(final_frame, emit_signal=False)
                 self.current_frame_changed.emit(final_frame)
             self._clear_key_drag_state()
             event.accept()
             return True
-        if self._key_drag_defer_selection and self._key_drag_candidate_frame is not None:
-            self._handle_key_click(
-                self._key_drag_candidate_frame,
-                self._key_drag_candidate_modifiers,
-            )
-            modifiers = self._key_drag_candidate_modifiers
+        if state.defer_selection and state.candidate_frame is not None:
+            self._handle_key_click(state.candidate_frame, state.candidate_modifiers)
+            modifiers = state.candidate_modifiers
             if not self._is_control_modifier(modifiers) and not (
                 modifiers & Qt.ShiftModifier
             ):
-                self.set_current_frame(self._key_drag_candidate_frame)
+                self.set_current_frame(state.candidate_frame)
         self._clear_key_drag_state()
         event.accept()
         return True

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -217,6 +217,7 @@ class MainWindow(QMainWindow):
         self.timeline_widget.key_remove_requested.connect(self.on_timeline_remove_key)
         self.timeline_widget.key_copy_requested.connect(self.on_timeline_copy_key)
         self.timeline_widget.key_paste_requested.connect(self.on_timeline_paste_key)
+        self.timeline_widget.key_move_requested.connect(self.on_timeline_move_keys)
         self.timeline_widget.frame_insert_requested.connect(
             self.on_timeline_insert_frame
         )
@@ -614,6 +615,10 @@ class MainWindow(QMainWindow):
         self.timeline_widget.set_has_copied_key(self.app.has_copied_keyframe())
         if pasted:
             self.timeline_widget.set_current_frame(frame)
+
+    @Slot(list)
+    def on_timeline_move_keys(self, frames: list[int]) -> None:
+        self.app.set_keyframes(frames)
 
     @Slot(int)
     def on_timeline_insert_frame(self, frame: int) -> None:

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -616,9 +616,9 @@ class MainWindow(QMainWindow):
         if pasted:
             self.timeline_widget.set_current_frame(frame)
 
-    @Slot(list)
-    def on_timeline_move_keys(self, frames: list[int]) -> None:
-        self.app.set_keyframes(frames)
+    @Slot(list, int)
+    def on_timeline_move_keys(self, frames: list[int], delta: int) -> None:
+        self.app.move_keyframes(frames, delta)
 
     @Slot(int)
     def on_timeline_insert_frame(self, frame: int) -> None:


### PR DESCRIPTION
## Summary
- allow the animation timeline widget to drag the currently selected keyframes, update their visuals during movement, and emit a move request when the drag ends
- wire the new move signal through the main window and app so the document controller can reposition keyframes on the active layer
- add a command that replaces the active layer's keyframe list to support undoable key moves

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5f789ecc8321a9384aed07fd3c90