### PR TITLE
Add timeline double-click key creation

### DIFF
--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -429,6 +429,16 @@ class AnimationTimelineWidget(QWidget):
             return
         super().mousePressEvent(event)
 
+    def mouseDoubleClickEvent(self, event: QMouseEvent) -> None:  # noqa: N802 - Qt naming
+        if event.button() == Qt.LeftButton:
+            frame = self._frame_at_point(event)
+            if frame not in self._keys:
+                self.key_add_requested.emit(frame)
+            self.set_current_frame(frame)
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
+
     def mouseMoveEvent(self, event: QMouseEvent) -> None:  # noqa: N802 - Qt naming
         if self._is_panning:
             if event.buttons() & Qt.MiddleButton:


### PR DESCRIPTION
## Summary
- create a new keyframe when the timeline receives a left-button double click on an un-keyed frame
- keep the clicked frame selected while deferring to existing behaviour when a key already exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cda716e99c832188e5175ba9c7b482