### PR TITLE
Add layer context action to merge current frame down

### DIFF
--- a/portal/ui/layer_list_widget.py
+++ b/portal/ui/layer_list_widget.py
@@ -3,6 +3,7 @@ from PySide6.QtCore import Qt, Signal
 
 class LayerListWidget(QListWidget):
     merge_down_requested = Signal(int)
+    merge_down_current_frame_requested = Signal(int)
     select_opaque_requested = Signal(int)
     duplicate_requested = Signal(int)
     remove_background_requested = Signal(int)
@@ -21,6 +22,7 @@ class LayerListWidget(QListWidget):
         index = self.row(item)
         menu = QMenu()
         merge_down_action = menu.addAction("Merge Down")
+        merge_down_current_frame_action = menu.addAction("Merge Down (Current Frame)")
         select_opaque_action = menu.addAction("Select Opaque")
         duplicate_action = menu.addAction("Duplicate")
         remove_bg_action = menu.addAction("Remove Background")
@@ -32,6 +34,8 @@ class LayerListWidget(QListWidget):
 
         if action == merge_down_action:
             self.merge_down_requested.emit(index)
+        elif action == merge_down_current_frame_action:
+            self.merge_down_current_frame_requested.emit(index)
         elif action == select_opaque_action:
             self.select_opaque_requested.emit(index)
         elif action == duplicate_action:

--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -36,6 +36,9 @@ class LayerManagerWidget(QWidget):
         self.layer_list.itemSelectionChanged.connect(self.on_selection_changed)
         self.layer_list.model().rowsMoved.connect(self.on_layers_moved)
         self.layer_list.merge_down_requested.connect(self.merge_layer_down)
+        self.layer_list.merge_down_current_frame_requested.connect(
+            self.merge_layer_down_current_frame
+        )
         self.layer_list.select_opaque_requested.connect(self.select_opaque)
         self.layer_list.duplicate_requested.connect(self.duplicate_layer_from_menu)
         self.layer_list.remove_background_requested.connect(self.remove_background_from_menu)
@@ -298,6 +301,16 @@ class LayerManagerWidget(QWidget):
         actual_index = len(document.layer_manager.layers) - 1 - index_in_list
         from portal.commands.layer_commands import MergeLayerDownCommand
         command = MergeLayerDownCommand(document, actual_index)
+        self.app.execute_command(command)
+
+    def merge_layer_down_current_frame(self, index_in_list):
+        document = self.app.document
+        if document is None:
+            return
+        actual_index = len(document.layer_manager.layers) - 1 - index_in_list
+        from portal.commands.layer_commands import MergeLayerDownCurrentFrameCommand
+
+        command = MergeLayerDownCurrentFrameCommand(document, actual_index)
         self.app.execute_command(command)
 
     def select_opaque(self, index_in_list):

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -18,6 +18,7 @@ import os
 from portal.commands.layer_commands import (
     RotateLayerCommand,
     MergeLayerDownCommand,
+    MergeLayerDownCurrentFrameCommand,
     CollapseLayersCommand,
     ScaleLayerCommand,
 )
@@ -1139,6 +1140,52 @@ def test_merge_layer_down_unifies_keyframes():
     bottom_frame2 = layer_at(2, bottom_uid)
     assert bottom_frame2.image.pixelColor(0, 1) == QColor("blue")
     assert bottom_frame2.image.pixelColor(1, 0) == QColor("green")
+
+
+def test_merge_layer_down_current_frame_creates_missing_key():
+    document = Document(2, 2)
+    frame_manager = document.frame_manager
+    layer_manager = document.layer_manager
+
+    bottom_layer = layer_manager.layers[0]
+    layer_manager.add_layer("Top")
+    top_layer = layer_manager.active_layer
+    document.register_layer(top_layer, layer_manager.active_layer_index)
+
+    frame_manager.ensure_frame(1)
+    document.select_frame(1)
+    layer_manager = document.layer_manager
+    frame_manager.add_layer_key(top_layer.uid, 1)
+
+    def layer_at(frame_index: int, layer_uid: int):
+        manager = document.frame_manager.frames[frame_index].layer_manager
+        for layer in manager.layers:
+            if layer.uid == layer_uid:
+                return layer
+        raise AssertionError("Layer not found")
+
+    layer_at(1, top_layer.uid).image.setPixelColor(0, 0, QColor("red"))
+
+    bottom_keys_before = document.frame_manager.layer_key_frames(bottom_layer.uid)
+    assert bottom_keys_before == [0]
+
+    command = MergeLayerDownCurrentFrameCommand(document, layer_manager.active_layer_index)
+    command.execute()
+
+    bottom_keys_after = document.frame_manager.layer_key_frames(bottom_layer.uid)
+    assert bottom_keys_after == [0, 1]
+    bottom_layer_frame1 = layer_at(1, bottom_layer.uid)
+    assert bottom_layer_frame1.image.pixelColor(0, 0) == QColor("red")
+    assert len(document.layer_manager.layers) == 2
+
+    command.undo()
+
+    restored_keys = document.frame_manager.layer_key_frames(bottom_layer.uid)
+    assert restored_keys == [0]
+    fallback_index = document.frame_manager.resolve_layer_key_frame_index(bottom_layer.uid, 1)
+    assert fallback_index == 0
+    fallback_layer = layer_at(fallback_index, bottom_layer.uid)
+    assert fallback_layer.image.pixelColor(0, 0) == QColor(0, 0, 0, 0)
 
 
 def test_collapse_layers_merges_entire_stack():


### PR DESCRIPTION
## Summary
- add a layer list context menu action that merges only the current frame into the layer below
- ensure the target layer key is created when missing and wire a new command with undo/redo support
- cover the new behaviour with a document and layers test

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cda66312e88321b9ff06d95ae81418