### PR TITLE
Preserve playback frames without keys during export

### DIFF
--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -134,6 +134,13 @@ class App(QObject):
     def set_auto_key_enabled(self, enabled: bool) -> None:
         self.document_controller.set_auto_key_enabled(enabled)
 
+    @property
+    def playback_total_frames(self) -> int:
+        return self.document_controller.playback_total_frames
+
+    def set_playback_total_frames(self, frame_count: int) -> None:
+        self.document_controller.set_playback_total_frames(frame_count)
+
     def ensure_auto_key_for_active_layer(self) -> bool:
         return self.document_controller.ensure_auto_key_for_active_layer()
 

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import QObject, Signal, Slot, QRect, Qt
 from PySide6.QtGui import QColor, QImage, QPainter
 from PySide6.QtWidgets import QMessageBox
 
+from portal.core.animation_player import DEFAULT_TOTAL_FRAMES
 from portal.core.document import Document
 from portal.core.undo import UndoManager
 from portal.core.drawing_context import DrawingContext
@@ -68,6 +69,7 @@ class DocumentController(QObject):
         self.main_window = None
         self._copied_key_state = None
         self.auto_key_enabled = False
+        self._playback_total_frames = DEFAULT_TOTAL_FRAMES
 
     # expose settings-backed properties
     @property
@@ -90,6 +92,19 @@ class DocumentController(QObject):
         if normalized == self.auto_key_enabled:
             return
         self.auto_key_enabled = normalized
+
+    @property
+    def playback_total_frames(self) -> int:
+        return self._playback_total_frames
+
+    def set_playback_total_frames(self, frame_count: int) -> None:
+        try:
+            normalized = int(frame_count)
+        except (TypeError, ValueError):
+            return
+        if normalized < 1:
+            normalized = 1
+        self._playback_total_frames = normalized
 
     def ensure_auto_key_for_active_layer(self) -> bool:
         """Create a keyframe on the active layer if auto-key is enabled."""

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -152,15 +152,26 @@ class DocumentService:
             app.config.set("General", "last_directory", app.last_directory)
 
         main_window = getattr(app, "main_window", None)
+        total_frames = None
         if main_window is not None:
             try:
                 total_frames = int(main_window.animation_player.total_frames)
             except (TypeError, ValueError):
-                total_frames = len(frame_manager.frames)
+                total_frames = None
             fps_value = getattr(main_window.animation_player, "fps", 12.0)
         else:
-            total_frames = len(frame_manager.frames)
             fps_value = 12.0
+
+        if total_frames is None:
+            playback_total = getattr(app, "playback_total_frames", None)
+            if playback_total is not None:
+                try:
+                    total_frames = int(playback_total)
+                except (TypeError, ValueError):
+                    total_frames = None
+
+        if total_frames is None:
+            total_frames = len(frame_manager.frames)
 
         if total_frames <= 0:
             total_frames = 1
@@ -317,6 +328,7 @@ class DocumentService:
             return
 
         app.attach_document(document)
+        app.set_playback_total_frames(len(frames))
         if app.main_window:
             app.main_window.apply_imported_animation_metadata(len(frames), fps)
         app.undo_manager.clear()

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -84,6 +84,7 @@ class MainWindow(QMainWindow):
         self.timeline_widget = AnimationTimelineWidget(self)
         self.timeline_widget.set_playback_total_frames(self.animation_player.total_frames)
         self.timeline_widget.set_total_frames(max(0, self.animation_player.total_frames - 1))
+        self.app.set_playback_total_frames(self.animation_player.total_frames)
 
         self.timeline_panel = QFrame(self)
         self.timeline_panel.setObjectName("animationTimelinePanel")
@@ -452,6 +453,7 @@ class MainWindow(QMainWindow):
             and self.animation_player.current_frame != current_frame
         ):
             self.animation_player.set_current_frame(current_frame)
+        self.app.set_playback_total_frames(value)
         self._update_stop_button_state()
 
     def apply_imported_animation_metadata(self, frame_count: int, fps: float) -> None:
@@ -522,6 +524,7 @@ class MainWindow(QMainWindow):
         playback_total = max(1, self.timeline_total_frames_spinbox.value())
         self.timeline_widget.set_playback_total_frames(playback_total)
         self.preview_panel.set_playback_total_frames(playback_total)
+        self.app.set_playback_total_frames(playback_total)
 
         document = self.app.document
         frame_manager = getattr(document, "frame_manager", None) if document else None


### PR DESCRIPTION
## Summary
- track the playback frame count on the document controller
- sync the main window timeline controls with the stored playback length
- fall back to the stored playback total when exporting or importing animations without a window

## Testing
- not run (Qt UI)

------
https://chatgpt.com/codex/tasks/task_e_68cdb8c5be3483219737e07c88137d51