### PR TITLE
Add AOLE document save and load support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Pixel-Portal is a lightweight, cross-platform image editor built with Python and
 - **Background Options**: Choose checkered, solid colors, or a custom image for the canvas background.
 - **Undo/Redo**: A robust undo/redo system to make editing easier and non-destructive.
 - **Customizable Interface**: A simple and intuitive interface that can be customized to your liking.
+- **Native Document Format**: Save and reopen complete projects with `.aole` files that preserve layers and animation frames.
 
 ## Getting Started
 

--- a/portal/core/aole_archive.py
+++ b/portal/core/aole_archive.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Iterable, Iterator, Mapping
+import zipfile
+
+from PySide6.QtCore import QBuffer
+from PySide6.QtGui import QImage
+
+from portal.core.frame import Frame
+from portal.core.frame_manager import FrameManager
+from portal.core.layer import Layer
+
+if TYPE_CHECKING:  # pragma: no cover - circular import safe-guard
+    from portal.core.document import Document
+
+
+class ArchiveFormatError(ValueError):
+    """Raised when an AOLE archive cannot be parsed."""
+
+
+@dataclass
+class _LayerRecord:
+    uid: int
+    name: str
+    visible: bool
+    opacity: float
+    image_path: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "uid": self.uid,
+            "name": self.name,
+            "visible": self.visible,
+            "opacity": self.opacity,
+            "image": self.image_path,
+        }
+
+
+@dataclass
+class _FrameRecord:
+    layers: list[_LayerRecord]
+    active_layer_index: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "active_layer_index": self.active_layer_index,
+            "layers": [layer.to_dict() for layer in self.layers],
+        }
+
+
+class AOLEArchive:
+    """Serialize and deserialize Pixel Portal documents."""
+
+    METADATA_FILE = "document.json"
+    IMAGE_ROOT = PurePosixPath("frames")
+    VERSION = 1
+
+    @classmethod
+    def save(cls, document: "Document", filename: str) -> None:
+        writer = _ArchiveWriter(document, cls.IMAGE_ROOT, cls.METADATA_FILE, cls.VERSION)
+        writer.write(filename)
+
+    @classmethod
+    def load(cls, document_cls: type["Document"], filename: str) -> "Document":
+        reader = _ArchiveReader(document_cls, cls.METADATA_FILE)
+        return reader.read(filename)
+
+
+class _ArchiveWriter:
+    def __init__(
+        self,
+        document: "Document",
+        image_root: PurePosixPath,
+        metadata_file: str,
+        version: int,
+    ) -> None:
+        self._document = document
+        self._image_root = image_root
+        self._metadata_file = metadata_file
+        self._version = version
+        self._binary_entries: dict[str, bytes] = {}
+
+    def write(self, filename: str) -> None:
+        metadata = self._build_metadata()
+
+        target_dir = os.path.dirname(filename) or "."
+        os.makedirs(target_dir, exist_ok=True)
+
+        with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for path, payload in sorted(self._binary_entries.items()):
+                archive.writestr(path, payload)
+            archive.writestr(
+                self._metadata_file,
+                json.dumps(metadata, indent=2).encode("utf-8"),
+            )
+
+    def _build_metadata(self) -> dict[str, object]:
+        document = self._document
+        frame_manager = document.frame_manager
+        metadata: dict[str, object] = {
+            "version": self._version,
+            "width": document.width,
+            "height": document.height,
+            "frames": [],
+            "frame_manager": {
+                "active_frame_index": frame_manager.active_frame_index,
+                "frame_markers": sorted(frame_manager.frame_markers),
+                "layer_keys": {
+                    str(layer_uid): sorted(self._normalize_frame_indices(indices))
+                    for layer_uid, indices in frame_manager.layer_keys.items()
+                },
+            },
+        }
+
+        for frame_index, frame in enumerate(frame_manager.frames):
+            frame_record = self._serialize_frame(frame, frame_index)
+            metadata["frames"].append(frame_record.to_dict())
+
+        return metadata
+
+    def _serialize_frame(self, frame: Frame, frame_index: int) -> _FrameRecord:
+        layer_manager = frame.layer_manager
+        layer_records: list[_LayerRecord] = []
+        for layer_index, layer in enumerate(layer_manager.layers):
+            image_bytes = self._encode_layer_image(layer)
+            image_filename = f"{layer.uid}_{layer_index}.png"
+            image_path = self._image_root / str(frame_index) / "layers" / image_filename
+            self._binary_entries[str(image_path)] = image_bytes
+            record = _LayerRecord(
+                uid=layer.uid,
+                name=layer.name,
+                visible=layer.visible,
+                opacity=layer.opacity,
+                image_path=str(image_path),
+            )
+            layer_records.append(record)
+
+        active_index = layer_manager.active_layer_index
+        if layer_records:
+            active_index = max(0, min(active_index, len(layer_records) - 1))
+        else:
+            active_index = -1
+
+        return _FrameRecord(layer_records, active_index)
+
+    @staticmethod
+    def _encode_layer_image(layer: Layer) -> bytes:
+        buffer = QBuffer()
+        buffer.open(QBuffer.ReadWrite)
+        layer.image.save(buffer, "PNG")
+        return bytes(buffer.data())
+
+    @staticmethod
+    def _normalize_frame_indices(indices: Iterable[int]) -> Iterator[int]:
+        for value in indices:
+            try:
+                index = int(value)
+            except (TypeError, ValueError):
+                continue
+            if index >= 0:
+                yield index
+
+
+class _ArchiveReader:
+    def __init__(self, document_cls: type["Document"], metadata_file: str) -> None:
+        self._document_cls = document_cls
+        self._metadata_file = metadata_file
+
+    def read(self, filename: str) -> "Document":
+        try:
+            with zipfile.ZipFile(filename, "r") as archive:
+                metadata = self._load_metadata(archive)
+                frame_manager = self._restore_frame_manager(metadata, archive)
+        except zipfile.BadZipFile as exc:  # pragma: no cover - zipfile error handling
+            raise ArchiveFormatError("The provided file is not a valid AOLE archive") from exc
+
+        width = int(metadata.get("width", 0))
+        height = int(metadata.get("height", 0))
+        if width <= 0 or height <= 0:
+            raise ArchiveFormatError("Invalid document dimensions in archive")
+
+        document = self._document_cls(width, height)
+        document.apply_frame_manager_snapshot(frame_manager)
+
+        self._sync_layer_uid_counter(document)
+
+        return document
+
+    def _load_metadata(self, archive: zipfile.ZipFile) -> dict[str, object]:
+        try:
+            metadata_bytes = archive.read(self._metadata_file)
+        except KeyError as exc:
+            raise ArchiveFormatError("Document metadata is missing from archive") from exc
+
+        try:
+            return json.loads(metadata_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ArchiveFormatError("Document metadata is malformed") from exc
+
+    def _restore_frame_manager(
+        self, metadata: Mapping[str, object], archive: zipfile.ZipFile
+    ) -> FrameManager:
+        width = int(metadata.get("width", 0))
+        height = int(metadata.get("height", 0))
+
+        frame_manager = FrameManager(width, height, frame_count=0)
+
+        frames_data = metadata.get("frames", [])
+        if not isinstance(frames_data, list):
+            raise ArchiveFormatError("Frame list is missing or invalid")
+
+        for frame_index, frame_data in enumerate(frames_data):
+            frame = Frame(width, height, create_background=False)
+            layer_manager = frame.layer_manager
+            layer_manager.layers = []
+
+            layers_data = self._extract_layers(frame_data)
+            for layer_position, layer_data in enumerate(layers_data):
+                layer = self._restore_layer(archive, layer_data, frame_index, layer_position)
+                layer_manager.layers.append(layer)
+
+            active_layer_index = self._normalize_index(
+                frame_data.get("active_layer_index"), len(layer_manager.layers)
+            )
+            layer_manager.active_layer_index = active_layer_index
+            frame_manager.frames.append(frame)
+
+        if not frame_manager.frames:
+            raise ArchiveFormatError("Document archive does not contain any frames")
+
+        self._apply_frame_manager_metadata(frame_manager, metadata)
+
+        rebind = getattr(frame_manager, "_rebind_all_layers", None)
+        if callable(rebind):
+            rebind()
+
+        return frame_manager
+
+    def _extract_layers(self, frame_data: Mapping[str, object]) -> list[Mapping[str, object]]:
+        layers = frame_data.get("layers", [])
+        if not isinstance(layers, list):
+            return []
+        return [layer for layer in layers if isinstance(layer, Mapping)]
+
+    def _restore_layer(
+        self,
+        archive: zipfile.ZipFile,
+        layer_data: Mapping[str, object],
+        frame_index: int,
+        layer_position: int,
+    ) -> Layer:
+        image_path = layer_data.get("image")
+        if not image_path:
+            raise ArchiveFormatError(
+                f"Layer {layer_position} in frame {frame_index} is missing image data"
+            )
+
+        try:
+            image_bytes = archive.read(str(image_path))
+        except KeyError as exc:
+            raise ArchiveFormatError(f"Missing layer image '{image_path}'") from exc
+
+        image = QImage()
+        if not image.loadFromData(image_bytes, "PNG"):
+            raise ArchiveFormatError(f"Layer image '{image_path}' could not be read")
+
+        name = layer_data.get("name") or f"Layer {layer_position + 1}"
+        layer = Layer.from_qimage(image, str(name))
+
+        layer.uid = self._coerce_int(layer_data.get("uid"), layer.uid)
+        layer.visible = self._coerce_bool(layer_data.get("visible"), True)
+        layer.opacity = self._coerce_float(layer_data.get("opacity"), 1.0, minimum=0.0, maximum=1.0)
+
+        return layer
+
+    def _apply_frame_manager_metadata(self, frame_manager: FrameManager, metadata: Mapping[str, object]) -> None:
+        manager_meta = metadata.get("frame_manager", {})
+        if not isinstance(manager_meta, Mapping):
+            manager_meta = {}
+
+        frame_count = len(frame_manager.frames)
+
+        raw_active_index = manager_meta.get("active_frame_index")
+        frame_manager.active_frame_index = self._normalize_index(raw_active_index, frame_count)
+
+        raw_markers = manager_meta.get("frame_markers", [])
+        frame_manager.frame_markers = self._normalize_marker_set(raw_markers, frame_count)
+
+        raw_layer_keys = manager_meta.get("layer_keys", {})
+        layer_keys = self._normalize_layer_keys(raw_layer_keys, frame_count, frame_manager)
+        frame_manager.layer_keys = layer_keys
+
+    def _normalize_layer_keys(
+        self,
+        raw_layer_keys: object,
+        frame_count: int,
+        frame_manager: FrameManager,
+    ) -> dict[int, set[int]]:
+        if not isinstance(raw_layer_keys, Mapping):
+            raw_layer_keys = {}
+
+        valid_layers = {
+            layer.uid
+            for frame in frame_manager.frames
+            for layer in frame.layer_manager.layers
+        }
+
+        normalized: dict[int, set[int]] = {}
+        for uid_str, frames in raw_layer_keys.items():
+            try:
+                layer_uid = int(uid_str)
+            except (TypeError, ValueError):
+                continue
+            if layer_uid not in valid_layers:
+                continue
+            indices = {
+                index
+                for index in self._iter_frame_indices(frames)
+                if 0 <= index < frame_count
+            }
+            if not indices and frame_count:
+                indices = {0}
+            normalized[layer_uid] = indices
+
+        if frame_count:
+            for uid in valid_layers:
+                normalized.setdefault(uid, {0})
+
+        return normalized
+
+    def _normalize_marker_set(self, values: object, frame_count: int) -> set[int]:
+        markers = {
+            index
+            for index in self._iter_frame_indices(values)
+            if 0 <= index < frame_count
+        }
+        if not markers and frame_count:
+            markers = {0}
+        return markers
+
+    def _iter_frame_indices(self, values: object) -> Iterator[int]:
+        if isinstance(values, Iterable) and not isinstance(values, (str, bytes)):
+            for value in values:
+                try:
+                    yield int(value)
+                except (TypeError, ValueError):
+                    continue
+
+    def _normalize_index(self, value: object, count: int) -> int:
+        if count <= 0:
+            return -1
+        try:
+            index = int(value)
+        except (TypeError, ValueError):
+            index = 0
+        return max(0, min(index, count - 1))
+
+    def _coerce_int(self, value: object, fallback: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return fallback
+
+    def _coerce_bool(self, value: object, fallback: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "1", "yes"}:
+                return True
+            if lowered in {"false", "0", "no"}:
+                return False
+        return fallback
+
+    def _coerce_float(
+        self,
+        value: object,
+        fallback: float,
+        *,
+        minimum: float | None = None,
+        maximum: float | None = None,
+    ) -> float:
+        try:
+            result = float(value)
+        except (TypeError, ValueError):
+            result = fallback
+        if minimum is not None:
+            result = max(minimum, result)
+        if maximum is not None:
+            result = min(maximum, result)
+        return result
+
+    def _sync_layer_uid_counter(self, document: "Document") -> None:
+        max_uid = 0
+        for frame in document.frame_manager.frames:
+            for layer in frame.layer_manager.layers:
+                max_uid = max(max_uid, layer.uid)
+        if max_uid > Layer._uid_counter:
+            Layer._uid_counter = max_uid
+

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -23,6 +23,7 @@ class Document:
         self.frame_manager = FrameManager(width, height)
         self._layer_manager_listeners: list[Callable[[LayerManager], None]] = []
         self._notify_layer_manager_changed()
+        self.file_path: str | None = None
 
     @property
     def layer_manager(self) -> LayerManager:
@@ -250,6 +251,8 @@ class Document:
                 description=json.dumps(layer_properties)
             )
 
+        self.file_path = filename
+
     @staticmethod
     def load_tiff(filename):
         with Image.open(filename) as img:
@@ -276,6 +279,7 @@ class Document:
                 doc.layer_manager.layers.append(layer)
                 doc.register_layer(layer, len(doc.layer_manager.layers) - 1)
 
+        doc.file_path = filename
         return doc
 
     def save_aole(self, filename: str) -> None:
@@ -326,6 +330,8 @@ class Document:
                 "document.json",
                 json.dumps(metadata, indent=2).encode("utf-8"),
             )
+
+        self.file_path = filename
 
     @classmethod
     def load_aole(cls, filename: str) -> "Document":
@@ -449,6 +455,8 @@ class Document:
 
         document = cls(width, height)
         document.apply_frame_manager_snapshot(frame_manager)
+
+        document.file_path = filename
 
         max_uid = 0
         for frame in document.frame_manager.frames:

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping
 import io
 import json
-import os
-import zipfile
 
 from PySide6.QtCore import QBuffer, QSize, Qt
 from PySide6.QtGui import QImage, QPainter
 from PIL import Image, ImageSequence, ImageQt
 
-from portal.core.frame import Frame
+from portal.core.aole_archive import AOLEArchive
 from portal.core.frame_manager import FrameManager
 from portal.core.layer import Layer
 from portal.core.layer_manager import LayerManager
@@ -285,187 +283,15 @@ class Document:
     def save_aole(self, filename: str) -> None:
         """Persist the entire document, including frames and layers, to an AOLE archive."""
 
-        frame_manager = self.frame_manager
-        metadata: dict[str, object] = {
-            "version": 1,
-            "width": self.width,
-            "height": self.height,
-            "frames": [],
-            "frame_manager": {
-                "active_frame_index": frame_manager.active_frame_index,
-                "frame_markers": sorted(frame_manager.frame_markers),
-                "layer_keys": {
-                    str(layer_uid): sorted(frames)
-                    for layer_uid, frames in frame_manager.layer_keys.items()
-                },
-            },
-        }
-
-        os.makedirs(os.path.dirname(filename) or ".", exist_ok=True)
-
-        with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-            for frame_index, frame in enumerate(frame_manager.frames):
-                layer_manager = frame.layer_manager
-                frame_entry: dict[str, object] = {
-                    "active_layer_index": layer_manager.active_layer_index,
-                    "layers": [],
-                }
-                for layer_position, layer in enumerate(layer_manager.layers):
-                    image_buffer = QBuffer()
-                    image_buffer.open(QBuffer.ReadWrite)
-                    layer.image.save(image_buffer, "PNG")
-                    image_path = f"frames/{frame_index}/layers/{layer.uid}_{layer_position}.png"
-                    archive.writestr(image_path, bytes(image_buffer.data()))
-                    layer_entry = {
-                        "uid": layer.uid,
-                        "name": layer.name,
-                        "visible": layer.visible,
-                        "opacity": layer.opacity,
-                        "image": image_path,
-                    }
-                    frame_entry["layers"].append(layer_entry)
-                metadata["frames"].append(frame_entry)
-
-            archive.writestr(
-                "document.json",
-                json.dumps(metadata, indent=2).encode("utf-8"),
-            )
-
+        AOLEArchive.save(self, filename)
         self.file_path = filename
 
     @classmethod
     def load_aole(cls, filename: str) -> "Document":
         """Load a full document, including animation data, from an AOLE archive."""
 
-        try:
-            with zipfile.ZipFile(filename, "r") as archive:
-                try:
-                    metadata_bytes = archive.read("document.json")
-                except KeyError as exc:
-                    raise ValueError("Document metadata is missing from archive") from exc
-                metadata = json.loads(metadata_bytes.decode("utf-8"))
-
-                width = int(metadata.get("width", 0))
-                height = int(metadata.get("height", 0))
-                if width <= 0 or height <= 0:
-                    raise ValueError("Invalid document dimensions in archive")
-
-                frame_manager = FrameManager(width, height, frame_count=0)
-                frames_data = metadata.get("frames", [])
-                for frame_data in frames_data:
-                    frame = Frame(width, height, create_background=False)
-                    layer_manager = frame.layer_manager
-                    layer_manager.layers = []
-                    try:
-                        active_layer_index = int(frame_data.get("active_layer_index", -1))
-                    except (TypeError, ValueError):
-                        active_layer_index = -1
-                    layers_data = frame_data.get("layers", [])
-                    for layer_data in layers_data:
-                        image_path = layer_data.get("image")
-                        if not image_path:
-                            continue
-                        try:
-                            image_bytes = archive.read(image_path)
-                        except KeyError as exc:
-                            raise ValueError(f"Missing layer image '{image_path}'") from exc
-                        qimage = QImage()
-                        if not qimage.loadFromData(image_bytes, "PNG"):
-                            raise ValueError(f"Layer image '{image_path}' could not be read")
-                        name = layer_data.get("name") or f"Layer {len(layer_manager.layers) + 1}"
-                        layer = Layer.from_qimage(qimage, name)
-                        try:
-                            layer.uid = int(layer_data.get("uid", layer.uid))
-                        except (TypeError, ValueError):
-                            layer.uid = layer.uid
-                        visible_value = layer_data.get("visible", True)
-                        if isinstance(visible_value, str):
-                            layer.visible = visible_value.lower() == "true"
-                        else:
-                            layer.visible = bool(visible_value)
-                        try:
-                            layer.opacity = float(layer_data.get("opacity", 1.0))
-                        except (TypeError, ValueError):
-                            layer.opacity = 1.0
-                        layer_manager.layers.append(layer)
-                    if layer_manager.layers:
-                        if active_layer_index < 0 or active_layer_index >= len(layer_manager.layers):
-                            active_layer_index = 0
-                    layer_manager.active_layer_index = active_layer_index
-                    frame_manager.frames.append(frame)
-
-                if not frame_manager.frames:
-                    raise ValueError("Document archive does not contain any frames")
-
-                frame_meta = metadata.get("frame_manager", {})
-                raw_layer_keys = frame_meta.get("layer_keys", {})
-                layer_keys: dict[int, set[int]] = {}
-                for uid_str, frames in raw_layer_keys.items():
-                    try:
-                        layer_uid = int(uid_str)
-                    except (TypeError, ValueError):
-                        continue
-                    normalized: set[int] = set()
-                    for value in frames:
-                        try:
-                            index = int(value)
-                        except (TypeError, ValueError):
-                            continue
-                        if index >= 0:
-                            normalized.add(index)
-                    if not normalized and frame_manager.frames:
-                        normalized = {0}
-                    layer_keys[layer_uid] = normalized
-
-                for frame in frame_manager.frames:
-                    for layer in frame.layer_manager.layers:
-                        if layer.uid not in layer_keys:
-                            layer_keys[layer.uid] = {0} if frame_manager.frames else set()
-
-                frame_manager.layer_keys = layer_keys
-
-                markers = frame_meta.get("frame_markers") or []
-                normalized_markers: set[int] = set()
-                for marker in markers:
-                    try:
-                        normalized_markers.add(int(marker))
-                    except (TypeError, ValueError):
-                        continue
-                frame_manager.frame_markers = normalized_markers
-                if not frame_manager.frame_markers and frame_manager.frames:
-                    frame_manager.frame_markers = {0}
-
-                try:
-                    active_index = int(frame_meta.get("active_frame_index", 0))
-                except (TypeError, ValueError):
-                    active_index = 0
-                if frame_manager.frames:
-                    active_index = max(0, min(active_index, len(frame_manager.frames) - 1))
-                else:
-                    active_index = -1
-                frame_manager.active_frame_index = active_index
-
-                if frame_manager.frames:
-                    rebind = getattr(frame_manager, "_rebind_all_layers", None)
-                    if callable(rebind):
-                        rebind()
-
-        except zipfile.BadZipFile as exc:
-            raise ValueError("The provided file is not a valid AOLE archive") from exc
-
-        document = cls(width, height)
-        document.apply_frame_manager_snapshot(frame_manager)
-
+        document = AOLEArchive.load(cls, filename)
         document.file_path = filename
-
-        max_uid = 0
-        for frame in document.frame_manager.frames:
-            for layer in frame.layer_manager.layers:
-                if layer.uid > max_uid:
-                    max_uid = layer.uid
-        if max_uid > Layer._uid_counter:
-            Layer._uid_counter = max_uid
-
         return document
 
     def resize(self, width, height, interpolation):

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -60,8 +60,6 @@ class DocumentController(QObject):
         self.document_service.app = self
         self.clipboard_service.app = self
 
-        self.attach_document(Document(64, 64))
-
         self.is_recording = False
         self.recorded_commands = []
         self._is_dirty = False
@@ -70,6 +68,8 @@ class DocumentController(QObject):
         self._base_window_title = "Pixel Portal"
         self._copied_key_state = None
         self.auto_key_enabled = False
+
+        self.attach_document(Document(64, 64))
 
     # expose settings-backed properties
     @property

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum, auto
 from typing import Iterable, Optional
 
@@ -63,9 +64,10 @@ class DocumentController(QObject):
 
         self.is_recording = False
         self.recorded_commands = []
-        self.is_dirty = False
+        self._is_dirty = False
 
-        self.main_window = None
+        self._main_window = None
+        self._base_window_title = "Pixel Portal"
         self._copied_key_state = None
         self.auto_key_enabled = False
 
@@ -81,6 +83,41 @@ class DocumentController(QObject):
     @last_directory.setter
     def last_directory(self, value):
         self.settings.last_directory = value
+
+    @property
+    def main_window(self):
+        return self._main_window
+
+    @main_window.setter
+    def main_window(self, window):
+        previous_window = getattr(self, "_main_window", None)
+        self._main_window = window
+        if window is None:
+            self._base_window_title = "Pixel Portal"
+        elif window is not previous_window:
+            title_accessor = getattr(window, "windowTitle", None)
+            if callable(title_accessor):
+                base_title = title_accessor()
+            elif isinstance(title_accessor, str):
+                base_title = title_accessor
+            else:
+                base_title = None
+            if not isinstance(base_title, str) or not base_title:
+                base_title = "Pixel Portal"
+            self._base_window_title = base_title
+        self._refresh_window_title()
+
+    @property
+    def is_dirty(self) -> bool:
+        return self._is_dirty
+
+    @is_dirty.setter
+    def is_dirty(self, value: bool) -> None:
+        normalized = bool(value)
+        previous = self._is_dirty
+        self._is_dirty = normalized
+        if normalized != previous:
+            self._refresh_window_title()
 
     def is_auto_key_enabled(self) -> bool:
         return bool(self.auto_key_enabled)
@@ -453,6 +490,27 @@ class DocumentController(QObject):
         self._layer_manager_unsubscribe = self.document.add_layer_manager_listener(
             self._bind_layer_manager
         )
+        self._refresh_window_title()
+
+    def update_main_window_title(self) -> None:
+        self._refresh_window_title()
+
+    def _refresh_window_title(self) -> None:
+        window = self._main_window
+        if window is None:
+            return
+        base_title = self._base_window_title or "Pixel Portal"
+        document = self.document
+        file_path = getattr(document, "file_path", None) if document is not None else None
+        title = base_title
+        if file_path:
+            display_name = os.path.basename(str(file_path))
+            if display_name:
+                title = f"{base_title} - {display_name}"
+        setter = getattr(window, "setWindowTitle", None)
+        if not callable(setter):
+            return
+        setter(title)
 
     def _bind_layer_manager(self, layer_manager):
         if layer_manager is self._layer_manager:

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -1,7 +1,6 @@
 import json
 import math
 import os
-import zipfile
 
 from PIL import Image
 from PySide6.QtGui import QImage, QImageReader, QPainter
@@ -55,7 +54,7 @@ class DocumentService:
                     document = Document(image.width(), image.height())
                     document.layer_manager.layers[0].image = image
                 document.file_path = file_path
-            except (ValueError, OSError, json.JSONDecodeError, zipfile.BadZipFile):
+            except (ValueError, OSError, json.JSONDecodeError):
                 message_box = QMessageBox()
                 message_box.setText("Unable to open the selected document.")
                 message_box.setInformativeText("The file appears to be corrupted or in an unsupported format.")

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -54,6 +54,7 @@ class DocumentService:
                         return
                     document = Document(image.width(), image.height())
                     document.layer_manager.layers[0].image = image
+                document.file_path = file_path
             except (ValueError, OSError, json.JSONDecodeError, zipfile.BadZipFile):
                 message_box = QMessageBox()
                 message_box.setText("Unable to open the selected document.")
@@ -69,6 +70,8 @@ class DocumentService:
             app.document_changed.emit()
             if app.main_window:
                 app.main_window.canvas.set_initial_zoom()
+            if hasattr(app, "update_main_window_title"):
+                app.update_main_window_title()
 
     def open_as_key(self):
         app = self.app
@@ -142,8 +145,11 @@ class DocumentService:
                     file_path = base_path + extension
                 image = app.document.render()
                 image.save(file_path)
-
+            if hasattr(app.document, "file_path"):
+                app.document.file_path = file_path
             app.is_dirty = False
+            if hasattr(app, "update_main_window_title"):
+                app.update_main_window_title()
 
     def export_animation(self):
         app = self.app

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPainter, QMouseEvent
 from unittest.mock import MagicMock, patch, Mock
 import os
+import zipfile
 from portal.commands.layer_commands import (
     RotateLayerCommand,
     MergeLayerDownCommand,
@@ -162,6 +163,15 @@ def test_save_load_aole(tmp_path):
         loaded.layer_manager.active_layer_index,
     )
     assert loaded.layer_manager.active_layer.uid > top_layer.uid
+
+
+def test_load_aole_missing_metadata(tmp_path):
+    archive_path = tmp_path / "broken.aole"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("frames/0/layers/0_0.png", b"")
+
+    with pytest.raises(ValueError):
+        Document.load_aole(str(archive_path))
 
 def test_flip_horizontal_vertical(document):
     """Test that all layers in the document are flipped correctly."""

--- a/tests/test_document_and_layers.py
+++ b/tests/test_document_and_layers.py
@@ -85,8 +85,10 @@ def test_save_load_tiff(document):
     """Test that a document with multiple layers can be saved and loaded as a TIFF file."""
     filepath = "test.tiff"
     document.save_tiff(filepath)
+    assert document.file_path == filepath
 
     loaded_document = Document.load_tiff(filepath)
+    assert loaded_document.file_path == filepath
 
     assert loaded_document.width == document.width
     assert loaded_document.height == document.height
@@ -132,7 +134,9 @@ def test_save_load_aole(tmp_path):
 
     save_path = tmp_path / "sample.aole"
     doc.save_aole(str(save_path))
+    assert doc.file_path == str(save_path)
     loaded = Document.load_aole(str(save_path))
+    assert loaded.file_path == str(save_path)
 
     assert loaded.width == doc.width
     assert loaded.height == doc.height


### PR DESCRIPTION
## Summary
- implement AOLE archive serialization for documents so frames, layers, and keyframes persist across sessions
- extend the open/save workflows to surface the new `.aole` format alongside existing image exports
- document the feature in the README and add regression coverage for saving and loading the archive

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68cdb85668088321af2c9462bc906186