### PR TITLE
Adjust save flow and window title indicators

### DIFF
--- a/portal/commands/action_manager.py
+++ b/portal/commands/action_manager.py
@@ -48,6 +48,10 @@ class ActionManager:
         self.save_action.setShortcut("Ctrl+S")
         self.save_action.triggered.connect(self.app.document_service.save_document)
 
+        self.save_as_action = QAction("Save &As...", self.main_window)
+        self.save_as_action.setShortcut("Ctrl+Shift+S")
+        self.save_as_action.triggered.connect(self.app.document_service.save_document_as)
+
         self.save_palette_as_png_action = QAction("Save Palette as PNG...", self.main_window)
         self.save_palette_as_png_action.triggered.connect(self.main_window.save_palette_as_png)
 

--- a/portal/commands/menu_bar_builder.py
+++ b/portal/commands/menu_bar_builder.py
@@ -30,6 +30,7 @@ class MenuBarBuilder:
         file_menu.addAction(self.action_manager.import_animation_action)
         file_menu.addAction(self.action_manager.export_animation_action)
         file_menu.addAction(self.action_manager.save_action)
+        file_menu.addAction(self.action_manager.save_as_action)
         file_menu.addSeparator()
         file_menu.addAction(self.action_manager.load_palette_action)
         file_menu.addAction(self.action_manager.save_palette_as_png_action)

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -516,12 +516,18 @@ class DocumentController(QObject):
             return
         base_title = self._base_window_title or "Pixel Portal"
         document = self.document
-        file_path = getattr(document, "file_path", None) if document is not None else None
+        display_name = ""
+        if document is not None:
+            file_path = getattr(document, "file_path", None)
+            if file_path:
+                display_name = os.path.basename(str(file_path)) or str(file_path)
+                if self.is_dirty:
+                    display_name = f"{display_name}*"
+            else:
+                display_name = "<unsaved>"
         title = base_title
-        if file_path:
-            display_name = os.path.basename(str(file_path))
-            if display_name:
-                title = f"{base_title} - {display_name}"
+        if display_name:
+            title = f"{base_title} - {display_name}"
         setter = getattr(window, "setWindowTitle", None)
         if not callable(setter):
             return

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -330,6 +330,7 @@ def test_setup_actions(mock_main_window):
     assert action_manager.open_action is not None
     assert action_manager.open_as_key_action is not None
     assert action_manager.save_action is not None
+    assert action_manager.save_as_action is not None
     assert action_manager.load_palette_action is not None
     assert action_manager.save_palette_as_png_action is not None
     assert action_manager.exit_action is not None
@@ -368,6 +369,9 @@ def test_setup_actions(mock_main_window):
 
     action_manager.save_action.trigger()
     mock_main_window.app.document_service.save_document.assert_called_once()
+
+    action_manager.save_as_action.trigger()
+    mock_main_window.app.document_service.save_document_as.assert_called_once()
 
     action_manager.load_palette_action.trigger()
     mock_main_window.load_palette_from_image.assert_called_once()

--- a/tests/test_document_controller_title.py
+++ b/tests/test_document_controller_title.py
@@ -1,0 +1,58 @@
+import pytest
+
+from portal.core.document_controller import DocumentController
+from portal.core.settings_controller import SettingsController
+
+
+class DummyWindow:
+    def __init__(self, title: str = "Pixel Portal"):
+        self._title = title
+        self.canvas = None
+
+    def windowTitle(self):
+        return self._title
+
+    def setWindowTitle(self, value: str) -> None:
+        self._title = value
+
+
+@pytest.fixture
+def controller(qapp):
+    return DocumentController(SettingsController())
+
+
+def test_window_title_for_unsaved_document(controller):
+    window = DummyWindow()
+    controller.main_window = window
+
+    assert window.windowTitle() == "Pixel Portal - <unsaved>"
+
+
+def test_window_title_updates_for_saved_document(tmp_path, controller):
+    window = DummyWindow()
+    controller.main_window = window
+
+    saved_path = tmp_path / "artwork.aole"
+    controller.document.file_path = str(saved_path)
+    controller.is_dirty = True
+
+    base_title = controller._base_window_title
+    expected_dirty = f"{base_title} - {saved_path.name}*"
+    assert window.windowTitle() == expected_dirty
+
+    controller.is_dirty = False
+    controller.update_main_window_title()
+
+    expected_clean = f"{base_title} - {saved_path.name}"
+    assert window.windowTitle() == expected_clean
+
+
+def test_window_title_respects_custom_base(tmp_path, qapp):
+    controller = DocumentController(SettingsController())
+    window = DummyWindow("Pixel Portal Deluxe")
+    controller.main_window = window
+
+    controller.document.file_path = str(tmp_path / "scene.png")
+    controller.update_main_window_title()
+
+    assert window.windowTitle() == "Pixel Portal Deluxe - scene.png"

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -1,0 +1,65 @@
+import configparser
+from pathlib import Path
+
+import pytest
+
+from portal.core.document import Document
+from portal.core.services.document_service import DocumentService, QFileDialog
+
+
+class DummyApp:
+    def __init__(self, directory: Path):
+        self.document = Document(8, 8)
+        self.last_directory = str(directory)
+        self.config = configparser.ConfigParser()
+        self.config.add_section("General")
+        self.is_dirty = True
+        self.updated_title = False
+        self.main_window = None
+
+    def update_main_window_title(self) -> None:
+        self.updated_title = True
+
+
+@pytest.fixture
+def document_service(tmp_path):
+    service = DocumentService()
+    service.app = DummyApp(tmp_path)
+    return service
+
+
+def test_save_document_as_updates_state(monkeypatch, document_service, tmp_path):
+    target = tmp_path / "sprite"
+
+    monkeypatch.setattr(
+        QFileDialog,
+        "getSaveFileName",
+        lambda *args, **kwargs: (str(target), "PNG (*.png)"),
+    )
+
+    document_service.save_document_as()
+
+    expected_path = target.with_suffix(".png")
+    app = document_service.app
+
+    assert app.document.file_path == str(expected_path)
+    assert expected_path.exists()
+    assert app.is_dirty is False
+    assert app.updated_title is True
+    assert app.last_directory == str(tmp_path)
+    assert app.config.get("General", "last_directory") == str(tmp_path)
+
+
+def test_save_document_uses_existing_path(monkeypatch, document_service, tmp_path):
+    existing = tmp_path / "existing.png"
+    document_service.app.document.file_path = str(existing)
+
+    save_as_calls = []
+    monkeypatch.setattr(document_service, "save_document_as", lambda: save_as_calls.append(True))
+
+    document_service.save_document()
+
+    assert not save_as_calls
+    assert existing.exists()
+    assert document_service.app.is_dirty is False
+    assert document_service.app.updated_title is True


### PR DESCRIPTION
## Summary
- update the main window title to flag unsaved documents and dirty saved files
- split the save logic so Save writes to the current file while Save As always prompts for a path
- expose a Save As action in the File menu and extend the action tests to cover it

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce3058b0f08321aac086cde950f302