### PR TITLE
Add onion skinning preview controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Pixel-Portal is a lightweight, cross-platform image editor built with Python and
 - **Layer Management**: Full support for layers, allowing for complex image compositions. You can add, remove, reorder, and merge layers.
 - **Frame-aware Rendering**: Canvas compositing and drawing tools operate on the active frame so animation edits stay isolated.
 - **Timeline Playback**: Play, pause, and loop your animation directly from the timeline, adjusting FPS and total frames without leaving the editor.
+- **Onion Skinning**: Preview previous and next frames directly on the canvas with adjustable ranges for confident animation tweaks.
 - **Selection Tools**: Tools for selecting parts of the image, including Rectangle, Circle, and Lasso selections.
 - **Image Manipulation**: Resize, crop, and flip the canvas.
 - **AI-Powered Image Generation**: Integrated with state-of-the-art AI models to generate images from text prompts.

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -86,6 +86,13 @@ class Canvas(QWidget):
         # Properties that were previously in App
         self._document_size = QSize(64, 64)
 
+        # Onion skin settings
+        self.onion_skin_enabled = False
+        self.onion_skin_prev_frames = 1
+        self.onion_skin_next_frames = 1
+        self.onion_skin_prev_color = QColor(255, 96, 96, 168)
+        self.onion_skin_next_color = QColor(96, 160, 255, 168)
+
         tool_defs = get_tools()
         self.tools = {tool_def["name"]: tool_def["class"](self) for tool_def in tool_defs}
         for tool in self.tools.values():
@@ -577,6 +584,40 @@ class Canvas(QWidget):
         self.document = document
         self.set_document_size(QSize(document.width, document.height))
         self.update()
+
+    def set_onion_skin_enabled(self, enabled: bool) -> None:
+        normalized = bool(enabled)
+        if normalized == self.onion_skin_enabled:
+            return
+        self.onion_skin_enabled = normalized
+        self.update()
+
+    def set_onion_skin_range(
+        self, *, previous: int | None = None, next: int | None = None
+    ) -> None:
+        changed = False
+        if previous is not None:
+            try:
+                normalized_prev = int(previous)
+            except (TypeError, ValueError):
+                normalized_prev = self.onion_skin_prev_frames
+            else:
+                normalized_prev = max(0, normalized_prev)
+            if normalized_prev != self.onion_skin_prev_frames:
+                self.onion_skin_prev_frames = normalized_prev
+                changed = True
+        if next is not None:
+            try:
+                normalized_next = int(next)
+            except (TypeError, ValueError):
+                normalized_next = self.onion_skin_next_frames
+            else:
+                normalized_next = max(0, normalized_next)
+            if normalized_next != self.onion_skin_next_frames:
+                self.onion_skin_next_frames = normalized_next
+                changed = True
+        if changed:
+            self.update()
 
     def paintEvent(self, event):
         painter = QPainter(self)

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -159,6 +159,45 @@ class MainWindow(QMainWindow):
         self.timeline_autokey_button.setChecked(self.app.is_auto_key_enabled())
         timeline_header_layout.addWidget(self.timeline_autokey_button)
 
+        self.timeline_onion_button = QToolButton(self.timeline_panel)
+        self.timeline_onion_button.setCheckable(True)
+        self.timeline_onion_button.setText("Onion")
+        self.timeline_onion_button.setToolTip("Toggle onion skinning preview")
+        self.timeline_onion_button.setAutoRaise(True)
+        self.timeline_onion_button.setFocusPolicy(Qt.NoFocus)
+        self.timeline_onion_button.setChecked(self.canvas.onion_skin_enabled)
+        if self.canvas.onion_skin_enabled:
+            self.timeline_onion_button.setText("Onion On")
+        timeline_header_layout.addWidget(self.timeline_onion_button)
+
+        self.timeline_onion_settings = QWidget(self.timeline_panel)
+        onion_settings_layout = QHBoxLayout(self.timeline_onion_settings)
+        onion_settings_layout.setContentsMargins(0, 0, 0, 0)
+        onion_settings_layout.setSpacing(4)
+
+        onion_prev_label = QLabel("Prev", self.timeline_onion_settings)
+        onion_prev_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        onion_settings_layout.addWidget(onion_prev_label)
+
+        self.timeline_onion_prev_spinbox = QSpinBox(self.timeline_onion_settings)
+        self.timeline_onion_prev_spinbox.setRange(0, 6)
+        self.timeline_onion_prev_spinbox.setFixedWidth(48)
+        self.timeline_onion_prev_spinbox.setValue(self.canvas.onion_skin_prev_frames)
+        onion_settings_layout.addWidget(self.timeline_onion_prev_spinbox)
+
+        onion_next_label = QLabel("Next", self.timeline_onion_settings)
+        onion_next_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        onion_settings_layout.addWidget(onion_next_label)
+
+        self.timeline_onion_next_spinbox = QSpinBox(self.timeline_onion_settings)
+        self.timeline_onion_next_spinbox.setRange(0, 6)
+        self.timeline_onion_next_spinbox.setFixedWidth(48)
+        self.timeline_onion_next_spinbox.setValue(self.canvas.onion_skin_next_frames)
+        onion_settings_layout.addWidget(self.timeline_onion_next_spinbox)
+
+        self.timeline_onion_settings.setEnabled(self.canvas.onion_skin_enabled)
+        timeline_header_layout.addWidget(self.timeline_onion_settings)
+
         self.timeline_current_frame_label = QLabel("Frame 0", self.timeline_panel)
         self.timeline_current_frame_label.setObjectName("animationTimelineCurrentFrameLabel")
         self.timeline_current_frame_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
@@ -207,6 +246,13 @@ class MainWindow(QMainWindow):
         self.timeline_autokey_button.toggled.connect(self._on_timeline_autokey_toggled)
         self.timeline_fps_slider.valueChanged.connect(self._on_timeline_fps_changed)
         self.timeline_total_frames_spinbox.valueChanged.connect(self._on_timeline_total_frames_changed)
+        self.timeline_onion_button.toggled.connect(self._on_timeline_onion_toggled)
+        self.timeline_onion_prev_spinbox.valueChanged.connect(
+            self._on_timeline_onion_prev_changed
+        )
+        self.timeline_onion_next_spinbox.valueChanged.connect(
+            self._on_timeline_onion_next_changed
+        )
 
         self.play_pause_shortcut = QShortcut(QKeySequence(Qt.Key_Space), self)
         self.play_pause_shortcut.setAutoRepeat(False)
@@ -401,6 +447,20 @@ class MainWindow(QMainWindow):
         )
         self.timeline_autokey_button.setIcon(icon)
         self.app.set_auto_key_enabled(enabled)
+
+    @Slot(bool)
+    def _on_timeline_onion_toggled(self, enabled: bool) -> None:
+        self.canvas.set_onion_skin_enabled(enabled)
+        self.timeline_onion_settings.setEnabled(enabled)
+        self.timeline_onion_button.setText("Onion On" if enabled else "Onion")
+
+    @Slot(int)
+    def _on_timeline_onion_prev_changed(self, value: int) -> None:
+        self.canvas.set_onion_skin_range(previous=value)
+
+    @Slot(int)
+    def _on_timeline_onion_next_changed(self, value: int) -> None:
+        self.canvas.set_onion_skin_range(next=value)
 
     @Slot(bool)
     def _on_timeline_play_toggled(self, checked: bool) -> None:


### PR DESCRIPTION
## Summary
- add configurable onion skin state to the canvas and expose toggle/range controls in the timeline header
- render previous and next frames with tinted overlays when onion skinning is enabled
- document the new onion skinning capability in the README

## Testing
- python -m compileall portal/core/renderer.py portal/ui/canvas.py portal/ui/ui.py

------
https://chatgpt.com/codex/tasks/task_e_68ce3914aee08321b4a16ca6f7947053