### PR TITLE
Add grid line color options in settings

### DIFF
--- a/portal/core/renderer.py
+++ b/portal/core/renderer.py
@@ -367,11 +367,8 @@ class CanvasRenderer:
         doc_height = self.canvas._document_size.height()
 
         # Define colors for grid lines
-        palette = self.canvas.palette()
-        minor_color = palette.color(QPalette.ColorRole.Mid)
-        minor_color.setAlpha(100)
-        major_color = palette.color(QPalette.ColorRole.Text)
-        major_color.setAlpha(100)
+        minor_color = QColor(self.canvas.grid_minor_color)
+        major_color = QColor(self.canvas.grid_major_color)
 
         major_spacing = max(1, int(self.canvas.grid_major_spacing))
         minor_spacing = max(1, int(self.canvas.grid_minor_spacing))

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -71,6 +71,10 @@ class Canvas(QWidget):
         self.grid_minor_visible = True
         self.grid_major_spacing = 8
         self.grid_minor_spacing = 1
+        self.grid_major_color = self.palette().color(QPalette.ColorRole.Text)
+        self.grid_major_color.setAlpha(100)
+        self.grid_minor_color = self.palette().color(QPalette.ColorRole.Mid)
+        self.grid_minor_color.setAlpha(100)
         self.tile_preview_enabled = False
         self.tile_preview_rows = 3
         self.tile_preview_cols = 3
@@ -593,6 +597,8 @@ class Canvas(QWidget):
         major_spacing=None,
         minor_visible=None,
         minor_spacing=None,
+        major_color=None,
+        minor_color=None,
     ):
         if major_visible is not None:
             self.grid_major_visible = bool(major_visible)
@@ -602,6 +608,14 @@ class Canvas(QWidget):
             self.grid_minor_visible = bool(minor_visible)
         if minor_spacing is not None:
             self.grid_minor_spacing = max(1, int(minor_spacing))
+        if major_color is not None:
+            color = QColor(major_color)
+            if color.isValid():
+                self.grid_major_color = color
+        if minor_color is not None:
+            color = QColor(minor_color)
+            if color.isValid():
+                self.grid_minor_color = color
         self.update()
 
     def get_grid_settings(self):
@@ -610,6 +624,8 @@ class Canvas(QWidget):
             "major_spacing": self.grid_major_spacing,
             "minor_visible": self.grid_minor_visible,
             "minor_spacing": self.grid_minor_spacing,
+            "major_color": self.grid_major_color.name(QColor.NameFormat.HexArgb),
+            "minor_color": self.grid_minor_color.name(QColor.NameFormat.HexArgb),
         }
 
     def resizeEvent(self, event):


### PR DESCRIPTION
## Summary
- add configurable major/minor grid colors to the settings dialog with color pickers
- persist chosen grid colors via the settings controller and apply them on the canvas renderer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cef944fc7483219df51980bde0d8ba