### PR TITLE
Switch ruler helper to segment divisions

### DIFF
--- a/portal/commands/status_bar_manager.py
+++ b/portal/commands/status_bar_manager.py
@@ -1,3 +1,5 @@
+import math
+
 from PySide6.QtWidgets import QLabel
 
 class StatusBarManager:
@@ -15,16 +17,19 @@ class StatusBarManager:
         self.main_window.selection_size_label = QLabel("")
         self.main_window.rotation_angle_label = QLabel("")
         self.main_window.scale_factor_label = QLabel("")
+        self.main_window.ruler_distance_label = QLabel("")
         status_bar.addWidget(self.main_window.cursor_pos_label)
         status_bar.addWidget(self.main_window.zoom_level_label)
         status_bar.addWidget(self.main_window.selection_size_label)
         status_bar.addWidget(self.main_window.rotation_angle_label)
         status_bar.addWidget(self.main_window.scale_factor_label)
+        status_bar.addWidget(self.main_window.ruler_distance_label)
 
     def _connect_signals(self):
         self.canvas.cursor_pos_changed.connect(self.update_cursor_pos_label)
         self.canvas.zoom_changed.connect(self.update_zoom_level_label)
         self.canvas.selection_size_changed.connect(self.update_selection_size_label)
+        self.canvas.ruler_distance_changed.connect(self.update_ruler_distance_label)
 
     def update_cursor_pos_label(self, pos):
         self.main_window.cursor_pos_label.setText(f"Cursor: ({pos.x()}, {pos.y()})")
@@ -50,3 +55,18 @@ class StatusBarManager:
             self.main_window.scale_factor_label.setText(f"Scale: {percent}%")
         else:
             self.main_window.scale_factor_label.setText("")
+
+    def update_ruler_distance_label(self, distance):
+        label = self.main_window.ruler_distance_label
+        if distance is None:
+            label.setText("")
+            return
+
+        if isinstance(distance, (int, float)) and math.isfinite(distance):
+            if math.isclose(distance, round(distance), abs_tol=0.05):
+                display_text = f"{int(round(distance))}"
+            else:
+                display_text = f"{distance:.1f}"
+            label.setText(f"Ruler: {display_text} px")
+        else:
+            label.setText("Ruler: 0 px")

--- a/portal/core/renderer.py
+++ b/portal/core/renderer.py
@@ -888,43 +888,6 @@ class CanvasRenderer:
             painter.setBrush(fill_color)
             painter.drawEllipse(rect)
 
-        if math.isfinite(distance):
-            if math.isclose(distance, round(distance), abs_tol=0.05):
-                distance_text = f"{int(round(distance))} px"
-            else:
-                distance_text = f"{distance:.1f} px"
-        else:
-            distance_text = "0 px"
-
-        mid_point = QPointF(
-            (start_center.x() + end_center.x()) / 2.0,
-            (start_center.y() + end_center.y()) / 2.0,
-        )
-
-        metrics = painter.fontMetrics()
-        text_bounds = metrics.boundingRect(distance_text)
-        padding_x = 8
-        padding_y = 4
-        label_rect = QRectF(
-            0,
-            0,
-            text_bounds.width() + padding_x * 2,
-            text_bounds.height() + padding_y * 2,
-        )
-        offset = handle_radius + label_rect.height() / 2.0 + 6
-        label_center = QPointF(
-            mid_point.x() + normal_x * offset,
-            mid_point.y() + normal_y * offset,
-        )
-        label_rect.moveCenter(label_center)
-
-        painter.setPen(Qt.NoPen)
-        painter.setBrush(QColor(0, 0, 0, 190))
-        painter.drawRoundedRect(label_rect, 4, 4)
-
-        painter.setPen(QColor(255, 255, 255))
-        painter.drawText(label_rect, Qt.AlignCenter, distance_text)
-
         painter.restore()
 
     def draw_grid(self, painter, target_rect):

--- a/portal/core/renderer.py
+++ b/portal/core/renderer.py
@@ -848,15 +848,20 @@ class CanvasRenderer:
         draw_tick_line(start_center, major_tick_length)
         draw_tick_line(end_center, major_tick_length)
 
-        interval_value = float(max(1, getattr(self.canvas, "_ruler_interval", 8)))
+        segments_value = int(
+            max(
+                1,
+                getattr(
+                    self.canvas,
+                    "_ruler_segments",
+                    getattr(self.canvas, "_ruler_interval", 2),
+                ),
+            )
+        )
         minor_tick_length = max(handle_radius * 1.4, 8.0)
-        if distance > 0 and interval_value > 0 and screen_length > 0:
-            steps = int(distance // interval_value)
-            for step_index in range(1, steps + 1):
-                distance_along = step_index * interval_value
-                if distance_along >= distance:
-                    break
-                ratio = distance_along / distance
+        if distance > 0 and segments_value > 1 and screen_length > 0:
+            for segment_index in range(1, segments_value):
+                ratio = segment_index / segments_value
                 doc_point = QPointF(
                     start_doc.x() + dx_doc * ratio,
                     start_doc.y() + dy_doc * ratio,

--- a/portal/ui/canvas.py
+++ b/portal/ui/canvas.py
@@ -128,7 +128,7 @@ class Canvas(QWidget):
         self._ruler_handle_hover: str | None = None
         self._ruler_handle_drag: str | None = None
         self._ruler_handle_prev_cursor: QCursor | None = None
-        self._ruler_interval = 8
+        self._ruler_segments = 2
 
         self.drawing_context.mirror_x_position_changed.connect(self.update)
         self.drawing_context.mirror_y_position_changed.connect(self.update)
@@ -1152,21 +1152,23 @@ class Canvas(QWidget):
                 self.grid_minor_color = color
         self.update()
 
-    def set_ruler_settings(self, *, interval=None):
-        if interval is None:
+    def set_ruler_settings(self, *, segments=None, interval=None):
+        if segments is None and interval is not None:
+            segments = interval
+        if segments is None:
             return
         try:
-            interval_value = int(interval)
+            segments_value = int(segments)
         except (TypeError, ValueError):
             return
-        interval_value = max(1, interval_value)
-        if interval_value == self._ruler_interval:
+        segments_value = max(1, segments_value)
+        if segments_value == self._ruler_segments:
             return
-        self._ruler_interval = interval_value
+        self._ruler_segments = segments_value
         self.update()
 
     def get_ruler_settings(self):
-        return {"interval": int(self._ruler_interval)}
+        return {"segments": int(self._ruler_segments)}
 
     def get_grid_settings(self):
         return {

--- a/portal/ui/settings_dialog.py
+++ b/portal/ui/settings_dialog.py
@@ -197,12 +197,12 @@ class SettingsDialog(QDialog):
             self._update_background_alpha_label
         )
 
-        canvas_layout.addWidget(QLabel("Ruler interval", canvas_tab), 2, 0)
-        self.ruler_interval_spinbox = QSpinBox(canvas_tab)
-        self.ruler_interval_spinbox.setMinimum(1)
-        self.ruler_interval_spinbox.setMaximum(4096)
-        canvas_layout.addWidget(self.ruler_interval_spinbox, 2, 1)
-        canvas_layout.addWidget(QLabel("px", canvas_tab), 2, 2)
+        canvas_layout.addWidget(QLabel("Ruler segments", canvas_tab), 2, 0)
+        self.ruler_segments_spinbox = QSpinBox(canvas_tab)
+        self.ruler_segments_spinbox.setMinimum(1)
+        self.ruler_segments_spinbox.setMaximum(4096)
+        canvas_layout.addWidget(self.ruler_segments_spinbox, 2, 1)
+        canvas_layout.addWidget(QLabel("segments", canvas_tab), 2, 2)
 
         self.canvas_reset_button = QPushButton("Reset to Defaults", canvas_tab)
         self.canvas_reset_button.clicked.connect(self._reset_canvas_tab)
@@ -245,12 +245,23 @@ class SettingsDialog(QDialog):
         self._update_background_alpha_label(clamped_percent)
 
         ruler_settings = self.settings_controller.get_ruler_settings()
-        interval = ruler_settings.get("interval", 8)
+        segments = ruler_settings.get(
+            "segments",
+            getattr(
+                self.settings_controller,
+                "DEFAULT_RULER_SEGMENTS",
+                2,
+            ),
+        )
         try:
-            interval_value = int(interval)
+            segments_value = int(segments)
         except (TypeError, ValueError):
-            interval_value = 8
-        self.ruler_interval_spinbox.setValue(max(1, interval_value))
+            segments_value = getattr(
+                self.settings_controller,
+                "DEFAULT_RULER_SEGMENTS",
+                2,
+            )
+        self.ruler_segments_spinbox.setValue(max(1, segments_value))
 
     def get_background_image_mode(self):
         data = self.background_mode_combo.currentData()
@@ -282,7 +293,7 @@ class SettingsDialog(QDialog):
 
     def get_ruler_settings(self):
         return {
-            "interval": self.ruler_interval_spinbox.value(),
+            "segments": self.ruler_segments_spinbox.value(),
         }
 
     def _apply_settings(self):
@@ -318,6 +329,9 @@ class SettingsDialog(QDialog):
         clamped_percent = max(0, min(100, percent))
         self.background_alpha_slider.setValue(clamped_percent)
         self._update_background_alpha_label(clamped_percent)
+        self.ruler_segments_spinbox.setValue(
+            getattr(self.settings_controller, "DEFAULT_RULER_SEGMENTS", 2)
+        )
 
     def _choose_major_grid_color(self):
         self._choose_grid_color("major")

--- a/portal/ui/settings_dialog.py
+++ b/portal/ui/settings_dialog.py
@@ -208,13 +208,13 @@ class SettingsDialog(QDialog):
         self.canvas_reset_button.clicked.connect(self._reset_canvas_tab)
         canvas_layout.addWidget(
             self.canvas_reset_button,
-            2,
+            3,
             0,
             1,
             3,
             alignment=Qt.AlignmentFlag.AlignRight,
         )
-        canvas_layout.setRowStretch(3, 1)
+        canvas_layout.setRowStretch(4, 1)
 
         self.tab_widget.addTab(canvas_tab, "Canvas")
 


### PR DESCRIPTION
## Summary
- replace the ruler interval setting with a segment count so the helper divides the guide evenly
- update the canvas, renderer, and settings plumbing to store segment counts while keeping compatibility with older configs
- refresh the settings dialog text and controls to expose the new segment spinner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf2dd49d1883219167f84e9acd9ea3