### PR TITLE
Add configurable negative prompt support for AI generation

### DIFF
--- a/portal/ai/image_generator.py
+++ b/portal/ai/image_generator.py
@@ -547,6 +547,8 @@ class ImageGenerator:
     def prompt_to_image(
         self,
         prompt: str,
+        *,
+        negative_prompt: str | None = None,
         original_size: tuple[int, int],
         generation_size: tuple[int, int] | None = None,
         num_inference_steps: int | None = None,
@@ -587,6 +589,8 @@ class ImageGenerator:
         }
         if coerced_generation_size:
             pipe_kwargs["width"], pipe_kwargs["height"] = coerced_generation_size
+        if negative_prompt is not None:
+            pipe_kwargs["negative_prompt"] = str(negative_prompt)
 
         print("Generating image from prompt...")
         generated_image = self.pipe(**pipe_kwargs).images[0]
@@ -604,6 +608,8 @@ class ImageGenerator:
         self,
         input_image: Image.Image,
         prompt: str,
+        *,
+        negative_prompt: str | None = None,
         strength: float | None = None,
         num_inference_steps: int | None = None,
         guidance_scale: float | None = None,
@@ -656,6 +662,8 @@ class ImageGenerator:
         }
         if target_generation_size:
             pipe_kwargs["width"], pipe_kwargs["height"] = target_generation_size
+        if negative_prompt is not None:
+            pipe_kwargs["negative_prompt"] = str(negative_prompt)
 
         generated_image = self.pipe(**pipe_kwargs).images[0]
 
@@ -673,6 +681,8 @@ class ImageGenerator:
         input_image: Image.Image,
         mask_image: Image.Image,
         prompt: str,
+        *,
+        negative_prompt: str | None = None,
         strength: float | None = None,
         num_inference_steps: int | None = None,
         guidance_scale: float | None = None,
@@ -729,6 +739,8 @@ class ImageGenerator:
         }
         if target_generation_size:
             pipe_kwargs["width"], pipe_kwargs["height"] = target_generation_size
+        if negative_prompt is not None:
+            pipe_kwargs["negative_prompt"] = str(negative_prompt)
 
         generated_image = self.pipe(**pipe_kwargs).images[0]
 

--- a/portal/core/settings_controller.py
+++ b/portal/core/settings_controller.py
@@ -26,7 +26,9 @@ class SettingsController(QObject):
     }
 
     DEFAULT_AI_SETTINGS = {
-        "negative_prompt": "",
+        "negative_prompt": (
+            "blurry, low quality, distorted, deformed, extra limbs, watermark, text"
+        ),
     }
 
     def __init__(self):

--- a/portal/core/settings_controller.py
+++ b/portal/core/settings_controller.py
@@ -25,6 +25,10 @@ class SettingsController(QObject):
         "image_alpha": 1.0,
     }
 
+    DEFAULT_AI_SETTINGS = {
+        "negative_prompt": "",
+    }
+
     def __init__(self):
         super().__init__()
         self.config = configparser.ConfigParser()
@@ -81,6 +85,15 @@ class SettingsController(QObject):
         )
         self._sync_ruler_settings_to_config()
 
+        if not self.config.has_section('AI'):
+            self.config.add_section('AI')
+        self.ai_negative_prompt = self.config.get(
+            'AI',
+            'negative_prompt',
+            fallback=self.DEFAULT_AI_SETTINGS["negative_prompt"],
+        )
+        self._sync_ai_settings_to_config()
+
     def save_settings(self, ai_settings=None):
         """Persist settings to disk."""
         try:
@@ -88,10 +101,13 @@ class SettingsController(QObject):
                 if not self.config.has_section('AI'):
                     self.config.add_section('AI')
                 self.config.set('AI', 'last_prompt', ai_settings.get('prompt', ''))
+                if 'negative_prompt' in ai_settings:
+                    self.ai_negative_prompt = str(ai_settings['negative_prompt'])
 
             self._sync_grid_settings_to_config()
             self._sync_background_settings_to_config()
             self._sync_ruler_settings_to_config()
+            self._sync_ai_settings_to_config()
 
             with open('settings.ini', 'w') as configfile:
                 self.config.write(configfile)
@@ -156,6 +172,11 @@ class SettingsController(QObject):
         if self.config.has_option('Ruler', 'interval'):
             self.config.remove_option('Ruler', 'interval')
 
+    def _sync_ai_settings_to_config(self):
+        if not self.config.has_section('AI'):
+            self.config.add_section('AI')
+        self.config.set('AI', 'negative_prompt', self.ai_negative_prompt or '')
+
     def get_grid_settings(self):
         return {
             'major_visible': self.grid_major_visible,
@@ -177,11 +198,19 @@ class SettingsController(QObject):
             'segments': int(self.ruler_segments),
         }
 
+    def get_ai_settings(self):
+        return {
+            'negative_prompt': self.ai_negative_prompt,
+        }
+
     def get_default_grid_settings(self):
         return dict(self.DEFAULT_GRID_SETTINGS)
 
     def get_default_background_settings(self):
         return dict(self.DEFAULT_BACKGROUND_SETTINGS)
+
+    def get_default_ai_settings(self):
+        return dict(self.DEFAULT_AI_SETTINGS)
 
     def update_grid_settings(
         self,
@@ -234,3 +263,8 @@ class SettingsController(QObject):
                 segments_value = self.ruler_segments
             self.ruler_segments = max(1, segments_value)
         self._sync_ruler_settings_to_config()
+
+    def update_ai_settings(self, *, negative_prompt=None):
+        if negative_prompt is not None:
+            self.ai_negative_prompt = str(negative_prompt)
+        self._sync_ai_settings_to_config()


### PR DESCRIPTION
## Summary
- add an AI tab to the settings dialog with controls for configuring a negative prompt and defaults
- persist the negative prompt via the settings controller and include it when saving AI settings
- feed the configured negative prompt into AI generations across prompt, img2img, and inpainting flows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d04dc6b2ac8321ae63c960c0a66495