### PR TITLE
Centralize layer lookups and fix related tooling

### DIFF
--- a/portal/commands/canvas_input_handler.py
+++ b/portal/commands/canvas_input_handler.py
@@ -108,7 +108,10 @@ class CanvasInputHandler:
             else:
                 self._force_tool(Qt.Key_Alt, "Picker")
         elif event.key() == Qt.Key_Control:
-            self._clear_forced_tool(Qt.Key_Control)
+            if self._is_selection_tool_active():
+                self._clear_forced_tool(Qt.Key_Control)
+            else:
+                self._force_tool(Qt.Key_Control, "Transform")
 
     def keyReleaseEvent(self, event):
         if event.key() == Qt.Key_Alt:

--- a/portal/commands/layer_commands.py
+++ b/portal/commands/layer_commands.py
@@ -16,13 +16,6 @@ if TYPE_CHECKING:
 rembg_remove = None
 
 
-def _find_layer_with_uid(layer_manager, layer_uid):
-    for layer in layer_manager.layers:
-        if getattr(layer, "uid", None) == layer_uid:
-            return layer
-    return None
-
-
 def _merge_layer_down_with_union(document: 'Document', layer_index: int) -> bool:
     layer_manager = document.layer_manager
     if not (0 < layer_index < len(layer_manager.layers)):
@@ -58,11 +51,8 @@ def _merge_layer_down_with_union(document: 'Document', layer_index: int) -> bool
         if not (0 <= top_source_index < len(frame_manager.frames)):
             continue
 
-        top_manager = frame_manager.frames[top_source_index].layer_manager
-        target_manager = frame_manager.frames[frame_index].layer_manager
-
-        top_source_layer = _find_layer_with_uid(top_manager, top_uid)
-        bottom_target_layer = _find_layer_with_uid(target_manager, bottom_uid)
+        top_source_layer = frame_manager.layer_for_frame(top_source_index, top_uid)
+        bottom_target_layer = frame_manager.layer_for_frame(frame_index, bottom_uid)
 
         if top_source_layer is None or bottom_target_layer is None:
             continue
@@ -118,11 +108,8 @@ def _merge_layer_down_current_frame(document: 'Document', layer_index: int) -> b
     if frame_index not in keys:
         frame_manager.add_layer_key(bottom_uid, frame_index)
 
-    source_manager = frame_manager.frames[source_frame_index].layer_manager
-    target_manager = frame_manager.frames[frame_index].layer_manager
-
-    source_layer = _find_layer_with_uid(source_manager, top_uid)
-    target_layer = _find_layer_with_uid(target_manager, bottom_uid)
+    source_layer = frame_manager.layer_for_frame(source_frame_index, top_uid)
+    target_layer = frame_manager.layer_for_frame(frame_index, bottom_uid)
     if source_layer is None or target_layer is None:
         return False
 

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -161,10 +161,9 @@ class Document:
         if previous_active_uid is not None:
             new_manager = self.frame_manager.current_layer_manager
             if new_manager is not None:
-                for position, layer in enumerate(new_manager.layers):
-                    if layer.uid == previous_active_uid:
-                        new_manager.select_layer(position)
-                        break
+                index = new_manager.index_for_layer_uid(previous_active_uid)
+                if index is not None:
+                    new_manager.select_layer(index)
         self._notify_layer_manager_changed()
 
     def render_current_frame(self) -> QImage:

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -686,27 +686,11 @@ class DocumentController(QObject):
             resolved = resolve_key(layer_uid, active_frame_index)
             keys = [resolved] if resolved is not None else []
 
-        visited_layers = set()
-        target_layers = []
-        frames = getattr(frame_manager, "frames", [])
-        for key_index in keys:
-            if key_index is None:
-                continue
-            if not (0 <= key_index < len(frames)):
-                continue
-            manager = frames[key_index].layer_manager
-            target_layer = None
-            for candidate in getattr(manager, "layers", []):
-                if getattr(candidate, "uid", None) == layer_uid:
-                    target_layer = candidate
-                    break
-            if target_layer is None:
-                continue
-            identity = id(target_layer)
-            if identity in visited_layers:
-                continue
-            visited_layers.add(identity)
-            target_layers.append(target_layer)
+        target_layers = list(
+            frame_manager.iter_layer_instances(
+                layer_uid, keys, ensure_frames=True
+            )
+        )
 
         if not target_layers:
             command = RemoveBackgroundCommand(layer)

--- a/portal/core/layer_manager.py
+++ b/portal/core/layer_manager.py
@@ -30,6 +30,29 @@ class LayerManager(QObject):
             return self.layers[self.active_layer_index]
         return None
 
+    # ------------------------------------------------------------------
+    # Layer lookup helpers
+    # ------------------------------------------------------------------
+    def index_for_layer_uid(self, layer_uid: int | None) -> int | None:
+        """Return the index of the layer with ``layer_uid`` if it exists."""
+
+        if layer_uid is None:
+            return None
+
+        for index, layer in enumerate(self.layers):
+            if getattr(layer, "uid", None) == layer_uid:
+                return index
+
+        return None
+
+    def find_layer_by_uid(self, layer_uid: int | None) -> Layer | None:
+        """Return the layer identified by ``layer_uid`` if present."""
+
+        index = self.index_for_layer_uid(layer_uid)
+        if index is None:
+            return None
+        return self.layers[index]
+
     def add_layer(self, name: str):
         """Adds a new layer to the top of the stack."""
         new_layer = Layer(self.width, self.height, name)

--- a/portal/core/renderer.py
+++ b/portal/core/renderer.py
@@ -848,16 +848,15 @@ class CanvasRenderer:
         draw_tick_line(start_center, major_tick_length)
         draw_tick_line(end_center, major_tick_length)
 
-        segments_value = int(
-            max(
-                1,
-                getattr(
-                    self.canvas,
-                    "_ruler_segments",
-                    getattr(self.canvas, "_ruler_interval", 2),
-                ),
-            )
+        raw_segments = getattr(
+            self.canvas,
+            "_ruler_segments",
+            getattr(self.canvas, "_ruler_interval", 2),
         )
+        try:
+            segments_value = max(1, int(raw_segments))
+        except (TypeError, ValueError):
+            segments_value = 1
         minor_tick_length = max(handle_radius * 1.4, 8.0)
         if distance > 0 and segments_value > 1 and screen_length > 0:
             for segment_index in range(1, segments_value):

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -1124,13 +1124,7 @@ class DocumentService:
 
     @staticmethod
     def _layer_instance_for_frame(frame_manager, frame_index, layer_uid):
-        if not (0 <= frame_index < len(frame_manager.frames)):
-            return None
-        manager = frame_manager.frames[frame_index].layer_manager
-        for layer in manager.layers:
-            if getattr(layer, "uid", None) == layer_uid:
-                return layer
-        return None
+        return frame_manager.layer_for_frame(frame_index, layer_uid)
 
     def _get_selected_image(self):
         app = self.app

--- a/portal/tools/baseselecttool.py
+++ b/portal/tools/baseselecttool.py
@@ -90,6 +90,7 @@ class BaseSelectTool(BaseTool):
         self._draft_selection_path = path
         preview = self._build_preview_path()
         self.canvas._update_selection_and_emit_size(preview)
+        setattr(self.canvas, "selection_shape", preview)
         return preview
 
     def _emit_preview_selection_changed(

--- a/portal/tools/movetool.py
+++ b/portal/tools/movetool.py
@@ -70,6 +70,13 @@ class MoveTool(BaseTool):
             return
         self.before_image = active_layer.image.copy()
 
+        image_size = active_layer.image.size()
+        image_format = active_layer.image.format()
+        if self.canvas.temp_image is None or self.canvas.temp_image.size() != image_size:
+            self.canvas.temp_image = QImage(image_size, image_format)
+        self.canvas.temp_image.fill(Qt.transparent)
+        self.canvas.original_image = active_layer.image.copy()
+
         if self.canvas.selection_shape:
             self.moving_selection = True
             self.original_selection_shape = QPainterPath(self.canvas.selection_shape)


### PR DESCRIPTION
## Summary
- add FrameManager helpers for resolving layer managers and layer instances, and update document services, controllers, and commands to rely on them instead of ad-hoc UID scans
- harden UI behaviour by restoring Ctrl→Transform switching, clamping ruler segment values, and making the preview panel tolerant of mock documents that only implement `render`
- refresh tool preview plumbing so selection previews and move operations rebuild their backing images when activated

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_core.py`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_dialogs.py`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_document_and_layers.py`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_drawing_tools.py`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_selection_tools.py`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_fit_canvas_to_selection.py`
- `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_tool_bar_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_68d0561b92a48321974633c38d012c5e