### PR TITLE
Add timeline loop range controls and playback updates

### DIFF
--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -151,6 +151,13 @@ class App(QObject):
     def set_playback_total_frames(self, frame_count: int) -> None:
         self.document_controller.set_playback_total_frames(frame_count)
 
+    @property
+    def playback_loop_range(self) -> tuple[int, int]:
+        return self.document_controller.playback_loop_range
+
+    def set_playback_loop_range(self, start: int, end: int) -> None:
+        self.document_controller.set_playback_loop_range(start, end)
+
     def ensure_auto_key_for_active_layer(self) -> bool:
         return self.document_controller.ensure_auto_key_for_active_layer()
 

--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -73,6 +73,8 @@ class DocumentController(QObject):
         self._copied_key_state = None
         self.auto_key_enabled = False
         self._playback_total_frames = DEFAULT_TOTAL_FRAMES
+        self._playback_loop_start = 0
+        self._playback_loop_end = max(0, self._playback_total_frames - 1)
 
         self._last_ai_output_rect = QRect()
         self.document_changed.connect(self._on_document_mutated)
@@ -165,6 +167,33 @@ class DocumentController(QObject):
         if normalized < 1:
             normalized = 1
         self._playback_total_frames = normalized
+        max_loop = max(0, self._playback_total_frames - 1)
+        if self._playback_loop_end > max_loop:
+            self._playback_loop_end = max_loop
+        if self._playback_loop_start > self._playback_loop_end:
+            self._playback_loop_start = self._playback_loop_end
+
+    @property
+    def playback_loop_range(self) -> tuple[int, int]:
+        return self._playback_loop_start, self._playback_loop_end
+
+    def set_playback_loop_range(self, start: int, end: int) -> None:
+        try:
+            start_value = int(start)
+            end_value = int(end)
+        except (TypeError, ValueError):
+            return
+        if start_value < 0:
+            start_value = 0
+        max_loop = max(0, self._playback_total_frames - 1)
+        if end_value < start_value:
+            end_value = start_value
+        if end_value > max_loop:
+            end_value = max_loop
+        if start_value > end_value:
+            start_value = end_value
+        self._playback_loop_start = start_value
+        self._playback_loop_end = end_value
 
     def ensure_auto_key_for_active_layer(self) -> bool:
         """Create a keyframe on the active layer if auto-key is enabled."""

--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from math import ceil
-from typing import Iterable, List, Set
+from typing import Dict, Iterable, List, Set
 
 from PySide6.QtCore import QPointF, QRectF, QSize, Qt, Signal
 from PySide6.QtGui import (
@@ -92,6 +92,8 @@ class AnimationTimelineWidget(QWidget):
     frame_insert_requested = Signal(int)
     frame_delete_requested = Signal(int)
     key_move_requested = Signal(list, int)
+    playback_total_frames_changed = Signal(int)
+    loop_range_changed = Signal(int, int)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -117,6 +119,15 @@ class AnimationTimelineWidget(QWidget):
         self._document_frame_count = 1
         self._drag_state = _KeyDragState()
         self._drag_state.clear()
+        self._loop_start = 0
+        self._loop_end = max(0, self._playback_total_frames - 1)
+        self._range_track_gap = 12.0
+        self._range_handle_width = 12.0
+        self._range_handle_height = 18.0
+        self._range_handle_padding = 4.0
+        self._active_range_handle: str | None = None
+        self._is_dragging_range_handle = False
+        self._range_handle_rects: Dict[str, QRectF] = {}
 
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.setMinimumHeight(100)
@@ -140,6 +151,11 @@ class AnimationTimelineWidget(QWidget):
 
         return self._playback_total_frames
 
+    def loop_range(self) -> Tuple[int, int]:
+        """Return the inclusive loop start/end frames."""
+
+        return self._loop_start, self._loop_end
+
     def set_total_frames(self, frame_count: int) -> None:
         """Define the minimum highest frame index displayed by the timeline."""
 
@@ -153,11 +169,12 @@ class AnimationTimelineWidget(QWidget):
     def set_playback_total_frames(self, frame_count: int) -> None:
         """Define the playback frame count used for colouring the timeline."""
 
-        frame_count = max(1, int(frame_count))
-        if frame_count == self._playback_total_frames:
-            return
-        self._playback_total_frames = frame_count
-        self.update()
+        self._apply_playback_total_frames(frame_count, from_user=False)
+
+    def set_loop_range(self, start: int, end: int) -> None:
+        """Define the loop start/end frames shown above the timeline."""
+
+        self._update_loop_range(start, end, emit_signal=False)
 
     def keys(self) -> List[int]:
         """Return the keyed frames sorted ascending."""
@@ -281,6 +298,9 @@ class AnimationTimelineWidget(QWidget):
         muted_selected_key_color = muted(selected_key_color)
         muted_selected_key_border = muted(selected_key_border)
 
+        total_range_color = palette.color(QPalette.Dark)
+        loop_range_color = palette.color(QPalette.Highlight)
+
         active_tick_pen = QPen(frame_color, 1.5)
         inactive_tick_pen = QPen(muted_frame_color, 1.5)
         active_number_pen = QPen(frame_color)
@@ -298,6 +318,54 @@ class AnimationTimelineWidget(QWidget):
 
         visible_start_x = self._margin
         visible_end_x = self.width() - self._margin
+
+        range_geometry = self._build_range_geometry(layout)
+        self._range_handle_rects = range_geometry["handles"]
+        extent_y = float(range_geometry["extent_y"])
+        loop_y = float(range_geometry["loop_y"])
+        total_start_x, total_end_x = range_geometry["total_line"]
+        loop_start_x, loop_end_x = range_geometry["loop_line"]
+
+        total_pen = QPen(total_range_color, 3)
+        total_pen.setCapStyle(Qt.RoundCap)
+        loop_pen = QPen(loop_range_color, 3)
+        loop_pen.setCapStyle(Qt.RoundCap)
+
+        painter.setPen(total_pen)
+        painter.drawLine(QPointF(total_start_x, extent_y), QPointF(total_end_x, extent_y))
+
+        painter.setPen(loop_pen)
+        painter.drawLine(QPointF(loop_start_x, loop_y), QPointF(loop_end_x, loop_y))
+
+        handle_border_color = palette.color(QPalette.Window)
+        painter.setPen(QPen(handle_border_color, 1.2))
+        active_handle = self._active_range_handle if self._is_dragging_range_handle else None
+
+        total_rect = self._range_handle_rects.get("total_end")
+        if total_rect is not None:
+            total_color = QColor(total_range_color)
+            if active_handle == "total_end":
+                total_color = total_color.lighter(120)
+            painter.setBrush(QBrush(total_color))
+            painter.drawRoundedRect(total_rect, 3, 3)
+
+        loop_start_rect = self._range_handle_rects.get("loop_start")
+        if loop_start_rect is not None:
+            loop_color = QColor(loop_range_color)
+            if active_handle == "loop_start":
+                loop_color = loop_color.lighter(120)
+            painter.setBrush(QBrush(loop_color))
+            painter.drawRoundedRect(loop_start_rect, 3, 3)
+
+        loop_end_rect = self._range_handle_rects.get("loop_end")
+        if loop_end_rect is not None:
+            loop_end_color = QColor(loop_range_color)
+            if active_handle == "loop_end":
+                loop_end_color = loop_end_color.lighter(120)
+            painter.setBrush(QBrush(loop_end_color))
+            painter.drawRoundedRect(loop_end_rect, 3, 3)
+
+        painter.setBrush(Qt.NoBrush)
 
         # Draw the main timeline bar.
         painter.setPen(QPen(guide_color, 2))
@@ -382,6 +450,21 @@ class AnimationTimelineWidget(QWidget):
 
     def mousePressEvent(self, event: QMouseEvent) -> None:  # noqa: N802 - Qt naming
         if event.button() == Qt.LeftButton:
+            layout = self._calculate_layout()
+            range_geometry = self._build_range_geometry(layout)
+            handle = self._hit_test_range_handle(event, range_geometry)
+            if handle:
+                self._active_range_handle = handle
+                self._is_dragging_range_handle = True
+                self._range_handle_initial_total = self._playback_total_frames
+                self._range_handle_initial_loop = (self._loop_start, self._loop_end)
+                self._clear_key_drag_state()
+                self._is_dragging = False
+                self.setCursor(Qt.SizeHorCursor)
+                self.update()
+                event.accept()
+                return
+            self._reset_range_handle_state()
             self._clear_key_drag_state()
             modifiers = event.modifiers()
             ctrl_down = self._is_control_modifier(modifiers)
@@ -423,6 +506,7 @@ class AnimationTimelineWidget(QWidget):
             event.accept()
             return
         if event.button() == Qt.MiddleButton:
+            self._reset_range_handle_state()
             self._is_panning = True
             self._last_pan_x = self._event_x(event)
             self.setCursor(Qt.ClosedHandCursor)
@@ -441,6 +525,12 @@ class AnimationTimelineWidget(QWidget):
         super().mouseDoubleClickEvent(event)
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:  # noqa: N802 - Qt naming
+        if self._is_dragging_range_handle:
+            if event.buttons() & Qt.LeftButton:
+                self._update_range_handle_drag(event)
+                event.accept()
+                return
+            self._reset_range_handle_state()
         if self._is_panning:
             if event.buttons() & Qt.MiddleButton:
                 self._update_pan(event)
@@ -468,6 +558,10 @@ class AnimationTimelineWidget(QWidget):
 
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:  # noqa: N802 - Qt naming
         if event.button() == Qt.LeftButton:
+            if self._is_dragging_range_handle:
+                self._reset_range_handle_state()
+                event.accept()
+                return
             if self._finish_key_drag(event):
                 return
             if self._is_dragging:
@@ -554,15 +648,172 @@ class AnimationTimelineWidget(QWidget):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-    def _frame_at_point(self, event) -> int:
+    def _frame_at_point(self, event, *, clamp: bool = True) -> int:
         x = self._event_x(event)
-        x = max(self._margin, min(x, self.width() - self._margin))
+        if clamp:
+            x = max(self._margin, min(x, self.width() - self._margin))
         layout = self._calculate_layout()
         if layout.spacing <= 0:
             return 0
         frame = round((x + self._scroll_offset - self._margin) / layout.spacing)
-        frame = max(0, min(frame, layout.max_frame))
+        if clamp:
+            frame = max(0, min(frame, layout.max_frame))
+        else:
+            frame = max(0, frame)
         return frame
+
+    def _frame_to_view_x(self, frame: float, layout: _TimelineLayout) -> float:
+        base = float(self._margin) + float(frame) * layout.spacing
+        return base - self._scroll_offset
+
+    def _build_range_geometry(self, layout: _TimelineLayout) -> Dict[str, object]:
+        spacing = layout.spacing
+        base_y = layout.track_y - self._tick_height / 2
+        extent_y = base_y - self._range_track_gap
+        min_extent = 8.0 + self._range_track_gap
+        if extent_y < min_extent:
+            extent_y = min_extent
+        loop_y = extent_y - self._range_track_gap
+        if loop_y < 8.0:
+            loop_y = 8.0
+        if loop_y > extent_y - 4.0:
+            loop_y = max(4.0, extent_y - 4.0)
+        if spacing <= 0:
+            base_x = float(self._margin) - self._scroll_offset
+            total_start_x = base_x
+            total_end_x = base_x
+            loop_start_x = base_x
+            loop_end_x = base_x
+        else:
+            total_last_index = max(0, self._playback_total_frames - 1)
+            total_start_x = self._frame_to_view_x(0, layout)
+            total_end_x = self._frame_to_view_x(total_last_index, layout)
+            if total_end_x < total_start_x:
+                total_end_x = total_start_x
+            loop_start_x = self._frame_to_view_x(self._loop_start, layout)
+            loop_end_x = self._frame_to_view_x(self._loop_end, layout)
+            if loop_end_x < loop_start_x:
+                loop_end_x = loop_start_x
+        handle_half_width = self._range_handle_width / 2.0
+        handle_height = self._range_handle_height
+        total_rect = QRectF(
+            total_end_x - handle_half_width,
+            extent_y - handle_height / 2.0,
+            self._range_handle_width,
+            handle_height,
+        )
+        loop_start_rect = QRectF(
+            loop_start_x - handle_half_width,
+            loop_y - handle_height / 2.0,
+            self._range_handle_width,
+            handle_height,
+        )
+        loop_end_rect = QRectF(
+            loop_end_x - handle_half_width,
+            loop_y - handle_height / 2.0,
+            self._range_handle_width,
+            handle_height,
+        )
+        handles: Dict[str, QRectF] = {
+            "total_end": total_rect,
+            "loop_start": loop_start_rect,
+            "loop_end": loop_end_rect,
+        }
+        return {
+            "extent_y": extent_y,
+            "loop_y": loop_y,
+            "total_line": (total_start_x, total_end_x),
+            "loop_line": (loop_start_x, loop_end_x),
+            "handles": handles,
+        }
+
+    def _hit_test_range_handle(
+        self, event: QMouseEvent, geometry: Dict[str, object]
+    ) -> str | None:
+        pos = event.position() if hasattr(event, "position") else event.pos()
+        handles = geometry.get("handles", {})
+        for name, rect in handles.items():
+            if not isinstance(rect, QRectF):
+                continue
+            expanded = rect.adjusted(
+                -self._range_handle_padding,
+                -self._range_handle_padding,
+                self._range_handle_padding,
+                self._range_handle_padding,
+            )
+            if expanded.contains(pos):
+                return name
+        return None
+
+    def _update_range_handle_drag(self, event: QMouseEvent) -> None:
+        handle = self._active_range_handle
+        if not handle:
+            return
+        if handle == "total_end":
+            frame = self._frame_at_point(event, clamp=False)
+            new_total = max(1, frame + 1)
+            self._apply_playback_total_frames(new_total, from_user=True)
+        elif handle == "loop_start":
+            frame = self._frame_at_point(event, clamp=False)
+            self._update_loop_range(frame, self._loop_end, emit_signal=True)
+        elif handle == "loop_end":
+            frame = self._frame_at_point(event, clamp=False)
+            self._update_loop_range(self._loop_start, frame, emit_signal=True)
+
+    def _reset_range_handle_state(self) -> None:
+        if self._is_dragging_range_handle or self._active_range_handle is not None:
+            self._is_dragging_range_handle = False
+            self._active_range_handle = None
+            self.unsetCursor()
+            self.update()
+
+    def _apply_playback_total_frames(self, frame_count: int, *, from_user: bool) -> None:
+        try:
+            normalized = int(frame_count)
+        except (TypeError, ValueError):
+            return
+        if normalized < 1:
+            normalized = 1
+        if normalized == self._playback_total_frames:
+            return
+        self._playback_total_frames = normalized
+        doc_max_index = self._document_frame_count - 1 if self._document_frame_count else 0
+        highest_key = max(self._keys) if self._keys else 0
+        target_base = max(doc_max_index, highest_key, self._playback_total_frames - 1)
+        if target_base != self._base_total_frames:
+            self._base_total_frames = target_base
+            self.updateGeometry()
+        max_loop = max(0, self._playback_total_frames - 1)
+        if self._loop_end > max_loop:
+            self._loop_end = max_loop
+        if self._loop_start > self._loop_end:
+            self._loop_start = self._loop_end
+        if from_user:
+            self.playback_total_frames_changed.emit(self._playback_total_frames)
+        self.update()
+
+    def _update_loop_range(self, start: int, end: int, *, emit_signal: bool) -> None:
+        try:
+            start_value = int(start)
+            end_value = int(end)
+        except (TypeError, ValueError):
+            return
+        if start_value < 0:
+            start_value = 0
+        max_loop = max(0, self._playback_total_frames - 1)
+        if end_value < start_value:
+            end_value = start_value
+        if end_value > max_loop:
+            end_value = max_loop
+        if start_value > end_value:
+            start_value = end_value
+        if self._loop_start == start_value and self._loop_end == end_value:
+            return
+        self._loop_start = start_value
+        self._loop_end = end_value
+        self.update()
+        if emit_signal:
+            self.loop_range_changed.emit(self._loop_start, self._loop_end)
 
     def _key_at_point(self, event: QMouseEvent) -> int | None:
         layout = self._calculate_layout()

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -84,7 +84,10 @@ class MainWindow(QMainWindow):
         self.timeline_widget = AnimationTimelineWidget(self)
         self.timeline_widget.set_playback_total_frames(self.animation_player.total_frames)
         self.timeline_widget.set_total_frames(max(0, self.animation_player.total_frames - 1))
+        self.timeline_widget.set_loop_range(0, max(0, self.animation_player.total_frames - 1))
+        self.animation_player.set_loop_range(0, max(0, self.animation_player.total_frames - 1))
         self.app.set_playback_total_frames(self.animation_player.total_frames)
+        self.app.set_playback_loop_range(0, max(0, self.animation_player.total_frames - 1))
 
         self.timeline_panel = QFrame(self)
         self.timeline_panel.setObjectName("animationTimelinePanel")
@@ -199,25 +202,6 @@ class MainWindow(QMainWindow):
         self.timeline_onion_settings.setEnabled(self.canvas.onion_skin_enabled)
         timeline_header_layout.addWidget(self.timeline_onion_settings)
 
-        self.timeline_current_frame_label = QLabel("Frame 0", self.timeline_panel)
-        self.timeline_current_frame_label.setObjectName("animationTimelineCurrentFrameLabel")
-        self.timeline_current_frame_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-        timeline_header_layout.addWidget(self.timeline_current_frame_label, 0)
-
-        total_frames_text_label = QLabel("Total", self.timeline_panel)
-        total_frames_text_label.setObjectName("animationTimelineTotalFramesLabel")
-        total_frames_text_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-        timeline_header_layout.addWidget(total_frames_text_label, 0)
-
-        self.timeline_total_frames_spinbox = QSpinBox(self.timeline_panel)
-        self.timeline_total_frames_spinbox.setObjectName("animationTimelineTotalFramesSpinBox")
-        self.timeline_total_frames_spinbox.setRange(1, 9999)
-        self.timeline_total_frames_spinbox.setAccelerated(True)
-        self.timeline_total_frames_spinbox.setKeyboardTracking(False)
-        self.timeline_total_frames_spinbox.setFixedWidth(80)
-        self.timeline_total_frames_spinbox.setValue(self.animation_player.total_frames)
-        timeline_header_layout.addWidget(self.timeline_total_frames_spinbox, 0)
-
         timeline_header_layout.addStretch()
 
         fps_label = QLabel("FPS", self.timeline_panel)
@@ -246,7 +230,6 @@ class MainWindow(QMainWindow):
         self.timeline_stop_button.clicked.connect(self._on_timeline_stop_clicked)
         self.timeline_autokey_button.toggled.connect(self._on_timeline_autokey_toggled)
         self.timeline_fps_slider.valueChanged.connect(self._on_timeline_fps_changed)
-        self.timeline_total_frames_spinbox.valueChanged.connect(self._on_timeline_total_frames_changed)
         self.timeline_onion_button.toggled.connect(self._on_timeline_onion_toggled)
         self.timeline_onion_prev_spinbox.valueChanged.connect(
             self._on_timeline_onion_prev_changed
@@ -259,6 +242,10 @@ class MainWindow(QMainWindow):
         self.play_pause_shortcut.setAutoRepeat(False)
         self.play_pause_shortcut.activated.connect(self._toggle_timeline_playback)
 
+        self.timeline_widget.playback_total_frames_changed.connect(
+            self._on_timeline_total_frames_changed
+        )
+        self.timeline_widget.loop_range_changed.connect(self._on_timeline_loop_range_changed)
         self.timeline_widget.current_frame_changed.connect(self._update_current_frame_label)
         self.timeline_widget.current_frame_changed.connect(self.on_timeline_frame_changed)
         self.timeline_widget.key_add_requested.connect(self.on_timeline_add_key)
@@ -366,6 +353,7 @@ class MainWindow(QMainWindow):
 
         # Preview Panel
         self.preview_panel.set_playback_total_frames(self.animation_player.total_frames)
+        self.preview_panel.set_loop_range(0, max(0, self.animation_player.total_frames - 1))
         self.preview_panel.set_playback_fps(self.animation_player.fps)
         self.preview_dock = QDockWidget("Preview", self)
         self.preview_dock.setWidget(self.preview_panel)
@@ -416,7 +404,6 @@ class MainWindow(QMainWindow):
         ])
 
     def _update_current_frame_label(self, frame: int) -> None:
-        self.timeline_current_frame_label.setText(f"Frame {frame}")
         self._update_stop_button_state()
 
     def _update_timeline_layer_label(self, layer_name: str | None) -> None:
@@ -506,27 +493,72 @@ class MainWindow(QMainWindow):
         self.timeline_widget.set_total_frames(target_base)
         self.timeline_widget.set_playback_total_frames(value)
         self.preview_panel.set_playback_total_frames(value)
-        timeline_blocker = QSignalBlocker(self.timeline_widget)
+        loop_start, loop_end = self.timeline_widget.loop_range()
+        max_loop_end = max(0, value - 1)
+        if loop_end > max_loop_end:
+            loop_end = max_loop_end
+        if loop_start > loop_end:
+            loop_start = loop_end
+        self.timeline_widget.set_loop_range(loop_start, loop_end)
+        self.preview_panel.set_loop_range(loop_start, loop_end)
         player_blocker = QSignalBlocker(self.animation_player)
         try:
             self.animation_player.set_total_frames(value)
+            self.animation_player.set_loop_range(loop_start, loop_end)
         finally:
             del player_blocker
-            del timeline_blocker
+        self.app.set_playback_total_frames(value)
+        self.app.set_playback_loop_range(loop_start, loop_end)
         current_frame = self.timeline_widget.current_frame()
+        if current_frame < loop_start:
+            self.timeline_widget.set_current_frame(loop_start)
+            current_frame = loop_start
+        elif current_frame > loop_end:
+            self.timeline_widget.set_current_frame(loop_end)
+            current_frame = loop_end
         if (
             current_frame < self.animation_player.total_frames
             and self.animation_player.current_frame != current_frame
         ):
             self.animation_player.set_current_frame(current_frame)
-        self.app.set_playback_total_frames(value)
+        self._update_stop_button_state()
+
+    @Slot(int, int)
+    def _on_timeline_loop_range_changed(self, start: int, end: int) -> None:
+        start_value = max(0, int(start))
+        end_value = max(start_value, int(end))
+        max_loop_end = max(0, self.timeline_widget.playback_total_frames() - 1)
+        if end_value > max_loop_end:
+            end_value = max_loop_end
+        if start_value > end_value:
+            start_value = end_value
+        if (start_value, end_value) != self.timeline_widget.loop_range():
+            self.timeline_widget.set_loop_range(start_value, end_value)
+        self.preview_panel.set_loop_range(start_value, end_value)
+        self.animation_player.set_loop_range(start_value, end_value)
+        self.app.set_playback_loop_range(start_value, end_value)
+        current_frame = self.timeline_widget.current_frame()
+        adjusted_frame = current_frame
+        if adjusted_frame < start_value:
+            adjusted_frame = start_value
+        elif adjusted_frame > end_value:
+            adjusted_frame = end_value
+        if adjusted_frame != current_frame:
+            self.timeline_widget.set_current_frame(adjusted_frame)
+            current_frame = adjusted_frame
+        if (
+            current_frame < self.animation_player.total_frames
+            and self.animation_player.current_frame != current_frame
+        ):
+            self.animation_player.set_current_frame(current_frame)
         self._update_stop_button_state()
 
     def apply_imported_animation_metadata(self, frame_count: int, fps: float) -> None:
         frame_total = max(1, int(frame_count))
-        with QSignalBlocker(self.timeline_total_frames_spinbox):
-            self.timeline_total_frames_spinbox.setValue(frame_total)
         self._on_timeline_total_frames_changed(frame_total)
+        loop_end = max(0, frame_total - 1)
+        self.timeline_widget.set_loop_range(0, loop_end)
+        self._on_timeline_loop_range_changed(0, loop_end)
 
         if isinstance(fps, (int, float)):
             fps_value = float(fps)
@@ -587,30 +619,43 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def sync_timeline_from_document(self):
-        playback_total = max(1, self.timeline_total_frames_spinbox.value())
+        playback_total = max(1, self.app.playback_total_frames)
+        loop_start, loop_end = self.app.playback_loop_range
+        loop_end = max(0, min(loop_end, playback_total - 1))
+        loop_start = max(0, min(loop_start, loop_end))
+
         self.timeline_widget.set_playback_total_frames(playback_total)
+        self.timeline_widget.set_loop_range(loop_start, loop_end)
         self.preview_panel.set_playback_total_frames(playback_total)
+        self.preview_panel.set_loop_range(loop_start, loop_end)
+        player_blocker = QSignalBlocker(self.animation_player)
+        try:
+            self.animation_player.set_total_frames(playback_total)
+            self.animation_player.set_loop_range(loop_start, loop_end)
+        finally:
+            del player_blocker
         self.app.set_playback_total_frames(playback_total)
+        self.app.set_playback_loop_range(loop_start, loop_end)
 
         document = self.app.document
         frame_manager = getattr(document, "frame_manager", None) if document else None
         if not document or frame_manager is None:
             self._update_timeline_layer_label(None)
             self.timeline_widget.set_document_frame_count(0)
+            loop_end_default = max(0, playback_total - 1)
             timeline_blocker = QSignalBlocker(self.timeline_widget)
             try:
-                self.timeline_widget.set_total_frames(max(0, playback_total - 1))
+                self.timeline_widget.set_total_frames(loop_end_default)
                 self.timeline_widget.set_keys([0])
-                self.timeline_widget.set_current_frame(0)
+                self.timeline_widget.set_current_frame(loop_start)
+                self.timeline_widget.set_loop_range(loop_start, loop_end_default)
             finally:
                 del timeline_blocker
-            player_blocker = QSignalBlocker(self.animation_player)
-            try:
-                self.animation_player.set_total_frames(playback_total)
-                if self.animation_player.current_frame != 0:
-                    self.animation_player.set_current_frame(0)
-            finally:
-                del player_blocker
+            if self.animation_player.current_frame != loop_start:
+                self.animation_player.set_current_frame(loop_start)
+            self.animation_player.set_loop_range(loop_start, loop_end_default)
+            self.preview_panel.set_loop_range(loop_start, loop_end_default)
+            self.app.set_playback_loop_range(loop_start, loop_end_default)
             self._update_current_frame_label(self.timeline_widget.current_frame())
             self._update_stop_button_state()
             return
@@ -638,12 +683,6 @@ class MainWindow(QMainWindow):
             self.timeline_widget.set_current_frame(current_frame)
         finally:
             del timeline_blocker
-
-        player_blocker = QSignalBlocker(self.animation_player)
-        try:
-            self.animation_player.set_total_frames(playback_total)
-        finally:
-            del player_blocker
 
         if (
             current_frame < self.animation_player.total_frames

--- a/tests/test_animation_player.py
+++ b/tests/test_animation_player.py
@@ -62,3 +62,78 @@ def test_animation_player_clamps_when_frame_count_shrinks(qapp):
 
     assert player.current_frame == 2
     assert observed == [2]
+
+
+def test_animation_player_respects_loop_range_when_setting(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(6)
+    player.set_current_frame(5)
+
+    player.set_loop_range(2, 4)
+
+    assert player.loop_start == 2
+    assert player.loop_end == 4
+    assert player.current_frame == 2
+
+
+def test_animation_player_stop_returns_to_loop_start(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(5)
+    player.set_loop_range(1, 3)
+    player.set_current_frame(2)
+
+    player.play()
+    qapp.processEvents()
+    player.stop()
+
+    assert player.current_frame == 1
+    assert not player.is_playing
+
+
+def test_animation_player_play_starts_within_loop(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(5)
+    player.set_current_frame(0)
+    player.set_loop_range(2, 4)
+
+    player.play()
+    qapp.processEvents()
+    assert player.current_frame == 2
+    player.pause()
+
+
+def test_animation_player_loop_range_updates_when_total_shrinks(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(6)
+    player.set_loop_range(1, 5)
+
+    player.set_total_frames(3)
+
+    assert player.loop_start == 1
+    assert player.loop_end == 2
+
+
+def test_animation_player_advances_with_custom_loop(qapp):
+    player = AnimationPlayer()
+    player.set_total_frames(5)
+    player.set_loop_range(1, 2)
+    player.set_fps(60)
+
+    frames: list[int] = []
+    loop = QEventLoop()
+
+    def on_frame(frame: int) -> None:
+        frames.append(frame)
+        if len(frames) >= 4:
+            player.pause()
+            if loop.isRunning():
+                loop.quit()
+
+    player.frame_changed.connect(on_frame)
+    player.play()
+
+    QTimer.singleShot(500, loop.quit)
+    loop.exec()
+
+    assert len(frames) >= 4
+    assert frames[:4] == [2, 1, 2, 1]


### PR DESCRIPTION
## Summary
- add loop range support to the animation player, controller, and preview panel
- redraw the timeline with playback and loop extent guides plus draggable handles for total frames and loop window
- update the main window to remove the frame/total labels, propagate loop settings, and expand animation player tests for the new behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d063807b348321a59f84910cb60419