### PR TITLE
Clear last remaining layer across frames

### DIFF
--- a/portal/ui/layer_manager_widget.py
+++ b/portal/ui/layer_manager_widget.py
@@ -264,12 +264,11 @@ class LayerManagerWidget(QWidget):
             except ValueError:
                 return
 
-            from portal.core.command import ClearLayerCommand
+            from portal.core.command import ClearLayerAndKeysCommand
 
             active_layer = layer_manager.active_layer
             if active_layer:
-                selection = self.canvas.selection_shape
-                command = ClearLayerCommand(active_layer, selection)
+                command = ClearLayerAndKeysCommand(self.app.document, active_layer)
                 self.app.execute_command(command)
         else:
             from portal.core.command import RemoveLayerCommand


### PR DESCRIPTION
## Summary
- add a ClearLayerAndKeysCommand that clears a layer across all frames and resets its keyframes
- hook the layer manager widget to use the new command when deleting the final remaining layer
- cover the behaviour with a regression test that exercises undo and redo

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d06873b2448321ac2dab369736bf9f