### PR TITLE
Persist animation FPS and move controls into settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pixel-Portal is a lightweight, cross-platform image editor built with Python and
 - **Drawing Tools**: A variety of tools for drawing and painting, including Pen, Bucket, Ellipse, Line, and Rectangle.
 - **Layer Management**: Full support for layers, allowing for complex image compositions. You can add, remove, reorder, and merge layers.
 - **Frame-aware Rendering**: Canvas compositing and drawing tools operate on the active frame so animation edits stay isolated.
-- **Timeline Playback**: Play, pause, and loop your animation directly from the timeline, adjusting FPS and total frames without leaving the editor.
+- **Timeline Playback**: Play, pause, and loop your animation directly from the timeline, while dialing in FPS and total frames through the Settings dialog.
 - **Onion Skinning**: Preview previous and next frames directly on the canvas with adjustable ranges for confident animation tweaks.
 - **Selection Tools**: Tools for selecting parts of the image, including Rectangle, Circle, and Lasso selections.
 - **Image Manipulation**: Resize, crop, and flip the canvas.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -260,9 +260,9 @@ Selections support move handles for repositioning. Use **Select → Invert** (`C
 - The frame counter displays playback length and the currently selected frame index. Adjust total playback frames to introduce holds without adding duplicate keys.
 
 ### 12.2 Onion skinning and playback controls
-- Onion skin sliders define how many previous/next frames appear and their opacity tint.
-- Playback controls (Play/Pause, FPS slider, loop toggle) live beneath the timeline. Press `Space` to toggle playback from anywhere in the window.
-- FPS adjustments update both the animation player and exported animation defaults.
+- Configure how many previous/next frames appear—and their tint—from the **Settings → Animation** tab.
+- Playback controls (Play/Pause, loop toggle) live beneath the timeline. Press `Space` to toggle playback from anywhere in the window.
+- Adjust the animation FPS in **Settings → Animation**. Changes apply to timeline playback and export defaults.
 
 ### 12.3 Previewing animations
 - The Preview dock mirrors the main playhead. Dock it beside the canvas for side-by-side reference or float it on a secondary display.
@@ -304,7 +304,7 @@ Ensure the optional AI libraries are installed (Section 3.3). GPU acceleration r
 
 ### 15.3 Exporting sprites and animations
 - **File → Export Animation** outputs GIF, APNG, or WebP. Choose the format from the save dialog filter; Pixel-Portal ensures the file extension matches the selected option.
-- The export inherits the current playback range and FPS. Adjust them on the timeline before exporting to control loop length and pacing.
+- The export inherits the current playback range and FPS. Adjust the playback range on the timeline and update FPS from **Settings → Animation** to control loop length and pacing.
 - For sprite sheets, export individual frames as PNGs by stepping through the timeline and using **File → Save As** with unique filenames.
 
 ## 16. Scripting and automation
@@ -317,6 +317,7 @@ Ensure the optional AI libraries are installed (Section 3.3). GPU acceleration r
 Open **Edit → Settings** (`Ctrl+,`) to configure:
 - **Grid tab:** Toggle major/minor grids, set spacing (1–1024 px), and choose colors.
 - **Canvas tab:** Pick background image mode (Fit, Stretch, Fill, Center), adjust background image opacity, and set ruler segment count.
+- **Animation tab:** Dial in playback FPS and onion-skin counts for the canvas and preview docks.
 - **AI tab:** Manage the default negative prompt text used by the AI panel.
 Use the **Reset to Defaults** button in each tab to revert to factory values. Apply commits changes without closing the dialog; OK saves and closes; Cancel discards pending edits.
 

--- a/portal/core/animation_player.py
+++ b/portal/core/animation_player.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import QObject, QTimer, Signal
 
 
 DEFAULT_TOTAL_FRAMES = 24
+DEFAULT_PLAYBACK_FPS = 12.0
 
 
 class AnimationPlayer(QObject):
@@ -17,7 +18,7 @@ class AnimationPlayer(QObject):
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._fps = 12.0
+        self._fps = DEFAULT_PLAYBACK_FPS
         self._total_frames = DEFAULT_TOTAL_FRAMES
         self._current_frame = 0
         self._is_playing = False

--- a/portal/core/app.py
+++ b/portal/core/app.py
@@ -158,6 +158,13 @@ class App(QObject):
     def set_playback_loop_range(self, start: int, end: int) -> None:
         self.document_controller.set_playback_loop_range(start, end)
 
+    @property
+    def playback_fps(self) -> float:
+        return self.document_controller.playback_fps
+
+    def set_playback_fps(self, fps: float) -> None:
+        self.document_controller.set_playback_fps(fps)
+
     def ensure_auto_key_for_active_layer(self) -> bool:
         return self.document_controller.ensure_auto_key_for_active_layer()
 

--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -14,10 +14,8 @@ from PIL import Image
 from PySide6.QtGui import QImage, QImageReader, QPainter
 from PySide6.QtWidgets import QFileDialog, QMessageBox
 
+from portal.core.animation_player import DEFAULT_PLAYBACK_FPS
 from portal.core.document import Document
-
-
-DEFAULT_PLAYBACK_FPS = 12.0
 
 
 @dataclass
@@ -312,11 +310,15 @@ class DocumentService:
         setter = getattr(app, "set_playback_total_frames", None)
         if callable(setter):
             setter(playback_total)
+        fps_value = Document.normalize_playback_fps(
+            getattr(document, "playback_fps", DEFAULT_PLAYBACK_FPS)
+        )
+        fps_setter = getattr(app, "set_playback_fps", None)
+        if callable(fps_setter):
+            fps_setter(fps_value)
         main_window = getattr(app, "main_window", None)
         if main_window is not None:
             apply_metadata = getattr(main_window, "apply_imported_animation_metadata", None)
-            animation_player = getattr(main_window, "animation_player", None)
-            fps_value = getattr(animation_player, "fps", DEFAULT_PLAYBACK_FPS)
             if callable(apply_metadata):
                 apply_metadata(playback_total, fps_value)
 
@@ -491,6 +493,10 @@ class DocumentService:
                 fps_value = self._sanitize_fps(
                     getattr(animation_player, "fps", DEFAULT_PLAYBACK_FPS)
                 )
+        else:
+            fps_value = self._sanitize_fps(
+                getattr(app, "playback_fps", fps_value)
+            )
 
         if total_frames is None:
             total_frames = self._safe_positive_int(getattr(app, "playback_total_frames", None))

--- a/portal/ui/layer_item_widget.py
+++ b/portal/ui/layer_item_widget.py
@@ -1,6 +1,15 @@
 from PySide6.QtCore import Signal, Qt, QRect
 from PySide6.QtGui import QPixmap, QPainter, QColor
-from PySide6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit, QStackedWidget, QSlider
+from PySide6.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QVBoxLayout,
+    QLabel,
+    QLineEdit,
+    QStackedWidget,
+    QSlider,
+    QSizePolicy,
+)
 
 
 class NameLabel(QLabel):
@@ -96,25 +105,25 @@ class LayerItemWidget(QWidget):
         self.setLayout(self.layout)
 
         icon_container = QWidget()
+        icon_container.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         icon_layout = QVBoxLayout(icon_container)
         icon_layout.setContentsMargins(0, 0, 0, 0)
-        icon_layout.setSpacing(2)
+        icon_layout.setSpacing(4)
+        icon_layout.setAlignment(Qt.AlignCenter)
 
         self.visibility_icon = ClickableLabel()
-        self.visibility_icon.setFixedWidth(24)
-        self.visibility_icon.setFixedHeight(24)
+        self.visibility_icon.setFixedSize(24, 24)
+        self.visibility_icon.setAlignment(Qt.AlignCenter)
         self.visibility_icon.clicked.connect(self.on_visibility_clicked)
-        icon_layout.addWidget(self.visibility_icon)
+        icon_layout.addWidget(self.visibility_icon, alignment=Qt.AlignCenter)
 
         self.onion_icon = ClickableLabel()
-        self.onion_icon.setFixedWidth(24)
-        self.onion_icon.setFixedHeight(24)
+        self.onion_icon.setFixedSize(24, 24)
         self.onion_icon.setToolTip("Toggle onion skin for this layer")
         self.onion_icon.clicked.connect(self.on_onion_clicked)
-        icon_layout.addWidget(self.onion_icon)
-
-        icon_layout.addStretch()
-        self.layout.addWidget(icon_container)
+        self.onion_icon.setAlignment(Qt.AlignCenter)
+        icon_layout.addWidget(self.onion_icon, alignment=Qt.AlignCenter)
+        self.layout.addWidget(icon_container, alignment=Qt.AlignVCenter)
 
         thumbnail_container = QWidget()
         thumbnail_layout = QHBoxLayout(thumbnail_container)


### PR DESCRIPTION
## Summary
* persist playback FPS in AOLE metadata and document instances, wiring the value through the app and document services so playback timing survives reloads
* relocate animation settings (FPS and onion-skin range) into the Settings dialog and synchronize runtime behaviour with the canvas and preview panels
* keep the active layer focused after auto-key operations and tidy the layer list icons so visibility and onion toggles share the same centered footprint
* refresh README and user manual entries to describe the new settings locations

## Testing
* not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ad8c39a48321b48fb944f9c46166