### PR TITLE
Fix Ctrl drag on timeline moving keys

### DIFF
--- a/portal/ui/animation_timeline_widget.py
+++ b/portal/ui/animation_timeline_widget.py
@@ -486,7 +486,7 @@ class AnimationTimelineWidget(QWidget):
             key_frame = self._key_at_point(event)
             if key_frame is not None:
                 self._is_dragging = False
-                if not ctrl_down and not shift_down and key_frame in self._selected_keys:
+                if not shift_down and key_frame in self._selected_keys:
                     self._prepare_key_drag(
                         key_frame,
                         modifiers=modifiers,


### PR DESCRIPTION
## Summary
- allow dragging a selected keyframe while Ctrl is held by reusing the drag preparation path
- keep Ctrl+click without movement toggling selection so range selection behaviour is unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0c58433588321a2a4de085d5a5766