### PR TITLE
Ensure timeline keys start empty and keep frame 0 blank

### DIFF
--- a/portal/core/frame_manager.py
+++ b/portal/core/frame_manager.py
@@ -86,6 +86,12 @@ class FrameManager:
                 target_manager.layers[target_index] = clone
 
 
+    def _clear_layer_key(self, layer_uid: int, frame_index: int) -> None:
+        layer = self.layer_for_frame(frame_index, layer_uid)
+        if layer is None:
+            return
+        layer.clear()
+
     def _copy_layer_between_layers(
         self, source_uid: int, target_uid: int, frame_index: int
     ) -> None:
@@ -418,17 +424,20 @@ class FrameManager:
         if all(source == target for source, target in normalized.items()):
             return False
 
+        blank_sources: Set[int] = set()
         for source, target in normalized.items():
             if source == target:
                 continue
             self._clone_layer_state(layer_uid, source, target)
+            if source == 0 and target != 0:
+                blank_sources.add(source)
 
         existing_keys = set(keys)
         target_positions = set(normalized.values())
 
         updated_keys = set(existing_keys)
         for source, target in normalized.items():
-            if source != target:
+            if source != target and source not in blank_sources:
                 updated_keys.discard(source)
         for target in target_positions:
             updated_keys.discard(target)
@@ -438,6 +447,9 @@ class FrameManager:
         if updated_keys == existing_keys:
             return False
         self.layer_keys[layer_uid] = updated_keys
+
+        for source in blank_sources:
+            self._clear_layer_key(layer_uid, source)
 
         self._refresh_frame_markers()
         self._rebind_layer_fallbacks(layer_uid)
@@ -456,6 +468,7 @@ class FrameManager:
         if source_index is None:
             source_index = 0
         self._clone_layer_state(layer_uid, source_index, index)
+        self._clear_layer_key(layer_uid, index)
         keys.add(index)
         self._refresh_frame_markers()
         self._rebind_layer_fallbacks(layer_uid)


### PR DESCRIPTION
## Summary
- add a helper that clears layer content and use it when adding a new keyframe so newly created keys start empty
- adjust keyframe move logic to retain frame 0 as a blank key when shifting keys away from the origin

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0cc6f38c48321981a5eeabb0ac6f8