### PR TITLE
Add deep_copy flag to layer cloning and adjust timeline usage

### DIFF
--- a/portal/commands/layer_commands.py
+++ b/portal/commands/layer_commands.py
@@ -182,11 +182,11 @@ class MergeLayerDownCommand(Command):
         if self._before_state is None:
             if not (0 < self.layer_index < len(self.document.layer_manager.layers)):
                 return
-            self._before_state = self.document.frame_manager.clone()
+            self._before_state = self.document.frame_manager.clone(deep_copy=True)
             if not _merge_layer_down_with_union(self.document, self.layer_index):
                 self._before_state = None
                 return
-            self._after_state = self.document.frame_manager.clone()
+            self._after_state = self.document.frame_manager.clone(deep_copy=True)
         else:
             if self._after_state is None:
                 return
@@ -213,11 +213,11 @@ class MergeLayerDownCurrentFrameCommand(Command):
                 return
             if not (0 < self.layer_index < layer_count):
                 return
-            self._before_state = self.document.frame_manager.clone()
+            self._before_state = self.document.frame_manager.clone(deep_copy=True)
             if not _merge_layer_down_current_frame(self.document, self.layer_index):
                 self._before_state = None
                 return
-            self._after_state = self.document.frame_manager.clone()
+            self._after_state = self.document.frame_manager.clone(deep_copy=True)
         else:
             if self._after_state is None:
                 return
@@ -241,10 +241,10 @@ class CollapseLayersCommand(Command):
             return
 
         if self._before_state is None:
-            self._before_state = self.document.frame_manager.clone()
+            self._before_state = self.document.frame_manager.clone(deep_copy=True)
             for index in range(layer_count - 1, 0, -1):
                 _merge_layer_down_with_union(self.document, index)
-            self._after_state = self.document.frame_manager.clone()
+            self._after_state = self.document.frame_manager.clone(deep_copy=True)
         else:
             if self._after_state is None:
                 return

--- a/portal/commands/timeline_commands.py
+++ b/portal/commands/timeline_commands.py
@@ -17,7 +17,7 @@ class _KeyframeCommand(Command):
 
     def _capture_before(self) -> None:
         if self._previous_state is None:
-            self._previous_state = self.document.frame_manager.clone()
+            self._previous_state = self.document.frame_manager.clone(deep_copy=True)
 
     def undo(self) -> None:
         if self._previous_state is None:

--- a/portal/core/command.py
+++ b/portal/core/command.py
@@ -502,7 +502,7 @@ class CropCommand(Command):
         if len(current_layers) != len(original_layers):
             # Fallback: replace the stack entirely if counts diverge (shouldn't
             # happen for crop but keeps undo resilient to future changes).
-            current_manager.layers = [layer.clone() for layer in original_layers]
+            current_manager.layers = [layer.clone(deep_copy=True) for layer in original_layers]
         else:
             for current_layer, original_layer in zip(current_layers, original_layers):
                 current_layer.image = original_layer.image.copy()
@@ -880,7 +880,9 @@ class DuplicateLayerCommand(Command):
         if self.duplicated_layer is None:
             # First execution
             original_layer = self.layer_manager.layers[self.index]
-            self.duplicated_layer = original_layer.clone(preserve_identity=False)
+            self.duplicated_layer = original_layer.clone(
+                preserve_identity=False, deep_copy=True
+            )
             self.duplicated_layer.name = f"{original_layer.name} copy"
             self.added_index = self.index + 1
 
@@ -946,11 +948,11 @@ class ClearLayerAndKeysCommand(Command):
             return
 
         if self._before_state is None:
-            self._before_state = frame_manager.clone()
-            working_state = frame_manager.clone()
+            self._before_state = frame_manager.clone(deep_copy=True)
+            working_state = frame_manager.clone(deep_copy=True)
             self._clear_layer_and_keys(working_state, layer_uid)
             document.apply_frame_manager_snapshot(working_state)
-            self._after_state = document.frame_manager.clone()
+            self._after_state = document.frame_manager.clone(deep_copy=True)
         else:
             if self._after_state is None:
                 return

--- a/portal/core/document.py
+++ b/portal/core/document.py
@@ -134,7 +134,7 @@ class Document:
 
     def clone(self):
         new_doc = Document(self.width, self.height)
-        new_doc.frame_manager = self.frame_manager.clone()
+        new_doc.frame_manager = self.frame_manager.clone(deep_copy=True)
         new_doc._notify_layer_manager_changed()
         new_doc.ai_output_rect = new_doc._normalize_ai_output_rect(self.ai_output_rect)
         new_doc.set_playback_total_frames(self.playback_total_frames)
@@ -335,7 +335,7 @@ class Document:
         self.frame_manager.duplicate_layer_keys(source_layer.uid, new_layer)
 
     def apply_frame_manager_snapshot(self, snapshot: FrameManager) -> None:
-        self.frame_manager = snapshot.clone()
+        self.frame_manager = snapshot.clone(deep_copy=True)
         self.width = self.frame_manager.width
         self.height = self.frame_manager.height
         self._notify_layer_manager_changed()

--- a/portal/core/frame.py
+++ b/portal/core/frame.py
@@ -51,8 +51,8 @@ class Frame:
 
         return final_image
 
-    def clone(self) -> "Frame":
-        """Create a deep copy of the frame and its layers."""
+    def clone(self, *, deep_copy: bool = False) -> "Frame":
+        """Create a copy of the frame and its layers."""
         cloned_frame = Frame(self.width, self.height, create_background=False)
-        cloned_frame.layer_manager = self.layer_manager.clone()
+        cloned_frame.layer_manager = self.layer_manager.clone(deep_copy=deep_copy)
         return cloned_frame

--- a/portal/core/layer_manager.py
+++ b/portal/core/layer_manager.py
@@ -170,10 +170,10 @@ class LayerManager(QObject):
         command = SetLayerOnionSkinCommand(self, index, not layer.onion_skin_enabled)
         self.command_generated.emit(command)
 
-    def clone(self):
-        """Creates a deep copy of the layer manager."""
+    def clone(self, *, deep_copy: bool = False):
+        """Create a copy of the layer manager."""
         new_manager = LayerManager(self.width, self.height, create_background=False)
-        new_manager.layers = [layer.clone() for layer in self.layers]
+        new_manager.layers = [layer.clone(deep_copy=deep_copy) for layer in self.layers]
         new_manager.active_layer_index = self.active_layer_index
         new_manager._document = self._document
         return new_manager

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -193,6 +193,21 @@ def test_clone_copies_frames_and_layers():
         assert len(cloned_frame.layer_manager.layers) == len(original_frame.layer_manager.layers)
 
 
+def test_cloned_key_state_snapshot_isolated_from_edits():
+    document = Document(2, 2)
+    layer = document.layer_manager.active_layer
+    layer.image.fill(QColor("red"))
+
+    snapshot = document.frame_manager.clone_layer_key_state(layer.uid, 0)
+
+    assert snapshot is not None
+    assert snapshot.image.cacheKey() != layer.image.cacheKey()
+
+    layer.image.fill(QColor("blue"))
+
+    assert snapshot.image.pixelColor(0, 0) == QColor("red")
+
+
 def test_document_key_frames_follow_frame_removal():
     document = Document(4, 4)
     document.add_frame()


### PR DESCRIPTION
## Summary
- add a deep_copy flag to Layer.clone/apply_key_state_from and thread through layer, frame, and frame-manager clones
- ensure timeline bookkeeping uses shallow clones while undo/keyframe commands request deep copies
- add a regression test verifying cloned key-state snapshots remain stable after edits

## Testing
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_frames.py


------
https://chatgpt.com/codex/tasks/task_e_68d0d2b9ee008321900f5b5f3df8bc9a