### PR TITLE
Reuse active layer data for tool previews

### DIFF
--- a/portal/tools/basetool.py
+++ b/portal/tools/basetool.py
@@ -94,6 +94,14 @@ class BaseTool(QObject):
         else:
             canvas.tile_preview_image = None
 
+    def _redraw_temp_from_preview_layer(self, layer=None) -> bool:
+        redraw = getattr(self.canvas, "redraw_temp_from_preview_layer", None)
+        if callable(redraw):
+            if layer is not None:
+                return bool(redraw(layer))
+            return bool(redraw())
+        return False
+
     def _refresh_preview_images(
         self,
         *,
@@ -126,6 +134,8 @@ class BaseTool(QObject):
         canvas.tile_preview_image = None
         canvas.temp_image_replaces_active_layer = False
         canvas.is_erasing_preview = False
+        if hasattr(canvas, "clear_preview_layer"):
+            canvas.clear_preview_layer()
 
     def _get_active_layer_manager(self):
         document = getattr(self.canvas, "document", None)

--- a/portal/tools/ellipsetool.py
+++ b/portal/tools/ellipsetool.py
@@ -26,12 +26,12 @@ class EllipseTool(BaseTool):
             return
 
         self.start_point = doc_pos
-        self._allocate_preview_images(replace_active_layer=True, allocate_temp=False)
+        self._allocate_preview_images(replace_active_layer=True)
         # The command will need the original image state
         self.command_generated.emit(("get_active_layer_image", "ellipse_tool_start"))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if self.canvas.original_image is None:
+        if not self._redraw_temp_from_preview_layer():
             return
 
         layer_manager = self._get_active_layer_manager()
@@ -42,7 +42,6 @@ class EllipseTool(BaseTool):
         if not active_layer or not active_layer.visible:
             return
 
-        self.canvas.temp_image = self.canvas.original_image.copy()
         self._refresh_preview_images(clear_temp=False)
 
         end_point = doc_pos
@@ -68,7 +67,7 @@ class EllipseTool(BaseTool):
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if self.canvas.original_image is None:
+        if getattr(self.canvas, "preview_layer", None) is None:
             return
 
         end_point = doc_pos

--- a/portal/tools/linetool.py
+++ b/portal/tools/linetool.py
@@ -17,14 +17,13 @@ class LineTool(BaseTool):
 
     def mousePressEvent(self, event: QMouseEvent, doc_pos: QPoint):
         self.start_point = doc_pos
-        self._allocate_preview_images(replace_active_layer=True, allocate_temp=False)
+        self._allocate_preview_images(replace_active_layer=True)
         self.command_generated.emit(("get_active_layer_image", "line_tool_start"))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if self.canvas.original_image is None:
+        if not self._redraw_temp_from_preview_layer():
             return
 
-        self.canvas.temp_image = self.canvas.original_image.copy()
         self._refresh_preview_images(clear_temp=False)
         self._paint_preview_line(
             self.canvas.temp_image,
@@ -44,7 +43,7 @@ class LineTool(BaseTool):
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if self.canvas.original_image is None:
+        if getattr(self.canvas, "preview_layer", None) is None:
             return
 
         layer_manager = self._get_active_layer_manager()

--- a/portal/tools/rectangletool.py
+++ b/portal/tools/rectangletool.py
@@ -26,11 +26,11 @@ class RectangleTool(BaseTool):
             return
 
         self.start_point = doc_pos
-        self._allocate_preview_images(replace_active_layer=True, allocate_temp=False)
+        self._allocate_preview_images(replace_active_layer=True)
         self.command_generated.emit(("get_active_layer_image", "rectangle_tool_start"))
 
     def mouseMoveEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if self.canvas.original_image is None:
+        if not self._redraw_temp_from_preview_layer():
             return
 
         layer_manager = self._get_active_layer_manager()
@@ -41,7 +41,6 @@ class RectangleTool(BaseTool):
         if not active_layer or not active_layer.visible:
             return
 
-        self.canvas.temp_image = self.canvas.original_image.copy()
         self._refresh_preview_images(clear_temp=False)
 
         end_point = doc_pos
@@ -67,7 +66,7 @@ class RectangleTool(BaseTool):
         self.canvas.update()
 
     def mouseReleaseEvent(self, event: QMouseEvent, doc_pos: QPoint):
-        if self.canvas.original_image is None:
+        if getattr(self.canvas, "preview_layer", None) is None:
             return
 
         end_point = doc_pos


### PR DESCRIPTION
## Summary
- add a canvas helper to track the preview layer and redraw the shared temp image from the live layer
- switch line, rectangle, ellipse, and move tools to rebuild previews from the active layer instead of copying QImages
- adjust canvas message handling and drawing-tool tests for the new preview flow

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d0d7efa8d8832199b145ccdbb0183f