### PR TITLE
Fix file dialog extension hint parsing

### DIFF
--- a/portal/core/services/document_service.py
+++ b/portal/core/services/document_service.py
@@ -4,6 +4,7 @@ import io
 import json
 import math
 import os
+import re
 from pathlib import Path
 from typing import Callable, Iterable
 import zlib
@@ -66,16 +67,14 @@ class DocumentService:
         "TIFF (*.tif *.tiff)",
     )
 
-    _FILTER_EXTENSION_HINTS: tuple[tuple[str, str], ...] = (
-        ("pixel portal document", ".aole"),
-        ("aole", ".aole"),
-        ("tiff", ".tiff"),
-        ("tif", ".tiff"),
-        ("jpeg", ".jpg"),
-        ("jpg", ".jpg"),
-        ("png", ".png"),
-        ("bmp", ".bmp"),
-    )
+    _FILTER_EXTENSION_PATTERN = re.compile(r"\*\.(\w+)")
+
+    _FILTER_EXTENSION_NORMALIZATION: dict[str, str] = {
+        ".jpeg": ".jpg",
+        ".jpg": ".jpg",
+        ".tif": ".tiff",
+        ".tiff": ".tiff",
+    }
 
     _RASTER_EXTENSIONS: frozenset[str] = frozenset({
         ".png",
@@ -266,11 +265,28 @@ class DocumentService:
     def _extract_extension_hint(self, selected_filter: str | None) -> str | None:
         if not selected_filter:
             return None
-        lowered = selected_filter.lower()
-        for token, extension in self._FILTER_EXTENSION_HINTS:
-            if token in lowered:
-                return extension
+
+        matches = self._FILTER_EXTENSION_PATTERN.findall(selected_filter.lower())
+        if not matches:
+            return None
+
+        canonical_extensions = {
+            self._normalize_filter_extension(match) for match in matches
+        }
+        canonical_extensions.discard("")
+        if len(canonical_extensions) == 1:
+            return canonical_extensions.pop()
         return None
+
+    @classmethod
+    def _normalize_filter_extension(cls, extension: str) -> str:
+        if not extension:
+            return ""
+
+        if not extension.startswith("."):
+            extension = f".{extension}"
+
+        return cls._FILTER_EXTENSION_NORMALIZATION.get(extension, extension)
 
     def _load_document_from_path(
         self, file_path: str, extension_hint: str | None

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -63,3 +63,18 @@ def test_save_document_uses_existing_path(monkeypatch, document_service, tmp_pat
     assert existing.exists()
     assert document_service.app.is_dirty is False
     assert document_service.app.updated_title is True
+
+
+@pytest.mark.parametrize(
+    "selected_filter, expected_extension",
+    [
+        ("Pixel Portal Document (*.aole)", ".aole"),
+        ("TIFF Files (*.tif *.tiff)", ".tiff"),
+        ("All Supported Files (*.aole *.png *.jpg *.bmp *.tif *.tiff)", None),
+        ("All Files (*)", None),
+    ],
+)
+def test_extract_extension_hint_handles_multi_extension_filters(
+    document_service, selected_filter, expected_extension
+):
+    assert document_service._extract_extension_hint(selected_filter) == expected_extension


### PR DESCRIPTION
## Summary
- avoid forcing the .aole loader when multi-extension filters such as "All Supported Files" are selected
- normalize filter extensions so TIFF aliases resolve correctly and add coverage for extension hint parsing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d169c2859c8321b5fca70711aac3e7