### PR TITLE
Fix rotation pivot handling during transform operations

### DIFF
--- a/portal/tools/transformtool.py
+++ b/portal/tools/transformtool.py
@@ -202,8 +202,13 @@ class TransformTool(BaseTool):
 
     # ------------------------------------------------------------------
     def _handle_scale_finished(self) -> None:
+        did_scale = bool(self._invoke(self._scale_tool, "consume_did_apply_scale"))
         self._refresh_scale_handles()
-        self._refresh_pivot()
+        if did_scale:
+            self._invoke(self._rotate_tool, "reset_pivot_to_default")
+            self._update_rotation_overlay_geometry()
+        else:
+            self._refresh_pivot()
 
     # ------------------------------------------------------------------
     def _handle_move_finished(self, delta: QPoint) -> None:


### PR DESCRIPTION
## Summary
- compute the rotation gizmo's default pivot from the same bounds used by scale handles and reset the angle offset before each drag
- track when scaling actually applies and recenter the pivot after scale operations so rotation always starts at 0 degrees
- expose helpers for transform tool to consume the scale flag and reset the pivot back to the transform centre

## Testing
- python -m compileall portal/tools/rotatetool.py portal/tools/scaletool.py portal/tools/transformtool.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b97fb5f88321ab7de611d0a82916