### PR TITLE
Cache layer non-transparent bounds for transform tools

### DIFF
--- a/portal/core/layer.py
+++ b/portal/core/layer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from PySide6.QtGui import QImage, QColor, QPainter
-from PySide6.QtCore import QSize, QObject, Signal, Qt
+from PySide6.QtCore import QSize, QObject, Signal, Qt, QRect
 
 class Layer(QObject):
     """
@@ -32,6 +32,10 @@ class Layer(QObject):
         self.image = QImage(QSize(width, height), QImage.Format_ARGB32)
         self.image.fill(QColor(0, 0, 0, 0))  # Fill with transparent
         self.uid = self._next_uid()
+
+        self._non_transparent_bounds: QRect | None = None
+        self._non_transparent_bounds_dirty = False
+        self.on_image_change.connect(self._mark_non_transparent_bounds_dirty)
 
     @property
     def name(self):
@@ -75,8 +79,9 @@ class Layer(QObject):
             painter.end()
         else:
             self.image.fill(QColor(0, 0, 0, 0))
-            
+
         self.on_image_change.emit()
+        self._set_non_transparent_bounds(None)
 
     def clone(
         self,
@@ -101,6 +106,7 @@ class Layer(QObject):
             new_layer.image = self.image.copy()
         else:
             new_layer.image = QImage(self.image)
+        new_layer._copy_non_transparent_bounds_from(self)
         return new_layer
 
     def apply_key_state_from(
@@ -116,6 +122,11 @@ class Layer(QObject):
         self.opacity = other.opacity
         self.onion_skin_enabled = other.onion_skin_enabled
         self.on_image_change.emit()
+        if isinstance(other, Layer):
+            self._copy_non_transparent_bounds_from(other)
+        else:
+            self._non_transparent_bounds = None
+            self._non_transparent_bounds_dirty = True
 
     def get_properties(self):
         """Returns a dictionary of layer properties."""
@@ -133,6 +144,8 @@ class Layer(QObject):
         height = qimage.height()
         layer = cls(width, height, name)
         layer.image = qimage
+        layer._non_transparent_bounds = None
+        layer._non_transparent_bounds_dirty = True
         return layer
 
     def flip_horizontal(self):
@@ -142,3 +155,87 @@ class Layer(QObject):
     def flip_vertical(self):
         self.image = self.image.flipped(Qt.Vertical)
         self.on_image_change.emit()
+
+    def _mark_non_transparent_bounds_dirty(self) -> None:
+        self._non_transparent_bounds_dirty = True
+
+    def _set_non_transparent_bounds(self, bounds: QRect | None) -> None:
+        if bounds is None:
+            self._non_transparent_bounds = None
+        else:
+            self._non_transparent_bounds = QRect(bounds)
+        self._non_transparent_bounds_dirty = False
+
+    def _copy_non_transparent_bounds_from(self, other: "Layer") -> None:
+        if other._non_transparent_bounds_dirty:
+            self._non_transparent_bounds = None
+            self._non_transparent_bounds_dirty = True
+        else:
+            self._set_non_transparent_bounds(other._non_transparent_bounds)
+
+    def mark_non_transparent_bounds_dirty(self) -> None:
+        self._non_transparent_bounds_dirty = True
+
+    @property
+    def non_transparent_bounds(self) -> QRect | None:
+        if self._non_transparent_bounds_dirty:
+            self._recalculate_non_transparent_bounds()
+        if self._non_transparent_bounds is None:
+            return None
+        return QRect(self._non_transparent_bounds)
+
+    def _recalculate_non_transparent_bounds(self) -> None:
+        bounds = self._calculate_non_transparent_bounds()
+        if bounds is None or not bounds.isValid() or bounds.isEmpty():
+            self._non_transparent_bounds = None
+        else:
+            self._non_transparent_bounds = bounds
+        self._non_transparent_bounds_dirty = False
+
+    def _calculate_non_transparent_bounds(self) -> QRect | None:
+        image = getattr(self, "image", None)
+        if image is None or image.isNull():
+            return None
+
+        width = image.width()
+        height = image.height()
+        if width <= 0 or height <= 0:
+            return None
+
+        left = width
+        right = -1
+        top = height
+        bottom = -1
+
+        for y in range(height):
+            row_left = None
+            row_right = None
+
+            for x in range(width):
+                if image.pixelColor(x, y).alpha() > 0:
+                    row_left = x
+                    break
+
+            if row_left is None:
+                continue
+
+            for x in range(width - 1, -1, -1):
+                if image.pixelColor(x, y).alpha() > 0:
+                    row_right = x
+                    break
+
+            if row_right is None:
+                continue
+
+            if row_left < left:
+                left = row_left
+            if row_right > right:
+                right = row_right
+            if top == height:
+                top = y
+            bottom = y
+
+        if right < left or bottom < top:
+            return None
+
+        return QRect(left, top, right - left + 1, bottom - top + 1)

--- a/portal/tools/rotatetool.py
+++ b/portal/tools/rotatetool.py
@@ -83,9 +83,10 @@ class RotateTool(BaseTool):
 
         layer_manager = self._get_active_layer_manager()
         if layer_manager and layer_manager.active_layer is not None:
-            image = layer_manager.active_layer.image
+            layer = layer_manager.active_layer
+            image = layer.image
             if image is not None and not image.isNull():
-                bounds = self._find_non_transparent_bounds(image)
+                bounds = layer.non_transparent_bounds
                 if bounds is None:
                     bounds = image.rect()
                 if bounds.isValid() and bounds.width() > 0 and bounds.height() > 0:
@@ -101,50 +102,6 @@ class RotateTool(BaseTool):
                 return QRect(0, 0, width_int, height_int)
 
         return None
-
-    def _find_non_transparent_bounds(self, image: QImage) -> QRect | None:
-        width = image.width()
-        height = image.height()
-        if width <= 0 or height <= 0:
-            return None
-
-        left = width
-        right = -1
-        top = height
-        bottom = -1
-
-        for y in range(height):
-            row_left = None
-            row_right = None
-
-            for x in range(width):
-                if image.pixelColor(x, y).alpha() > 0:
-                    row_left = x
-                    break
-
-            if row_left is None:
-                continue
-
-            for x in range(width - 1, -1, -1):
-                if image.pixelColor(x, y).alpha() > 0:
-                    row_right = x
-                    break
-
-            if row_right is None:
-                continue
-
-            if row_left < left:
-                left = row_left
-            if row_right > right:
-                right = row_right
-            if top == height:
-                top = y
-            bottom = y
-
-        if right < left or bottom < top:
-            return None
-
-        return QRect(left, top, right - left + 1, bottom - top + 1)
 
     def get_rotation_center_doc(self) -> QPoint:
         return self.pivot_doc

--- a/portal/tools/scaletool.py
+++ b/portal/tools/scaletool.py
@@ -559,9 +559,10 @@ class ScaleTool(BaseTool):
 
         layer_manager = self._get_active_layer_manager()
         if layer_manager and layer_manager.active_layer is not None:
-            image = layer_manager.active_layer.image
+            layer = layer_manager.active_layer
+            image = layer.image
             if image is not None and not image.isNull():
-                bounds = self._find_non_transparent_bounds(image)
+                bounds = layer.non_transparent_bounds
                 if bounds is None:
                     bounds = image.rect()
                 if bounds.isValid() and bounds.width() > 0 and bounds.height() > 0:
@@ -577,51 +578,6 @@ class ScaleTool(BaseTool):
                 return QRectF(0, 0, width_int, height_int)
 
         return None
-
-    # ------------------------------------------------------------------
-    def _find_non_transparent_bounds(self, image: QImage) -> QRect | None:
-        width = image.width()
-        height = image.height()
-        if width <= 0 or height <= 0:
-            return None
-
-        left = width
-        right = -1
-        top = height
-        bottom = -1
-
-        for y in range(height):
-            row_left = None
-            row_right = None
-
-            for x in range(width):
-                if image.pixelColor(x, y).alpha() > 0:
-                    row_left = x
-                    break
-
-            if row_left is None:
-                continue
-
-            for x in range(width - 1, -1, -1):
-                if image.pixelColor(x, y).alpha() > 0:
-                    row_right = x
-                    break
-
-            if row_right is None:
-                continue
-
-            if row_left < left:
-                left = row_left
-            if row_right > right:
-                right = row_right
-            if top == height:
-                top = y
-            bottom = y
-
-        if right < left or bottom < top:
-            return None
-
-        return QRect(left, top, right - left + 1, bottom - top + 1)
 
     # ------------------------------------------------------------------
     def _current_pivot_point(self) -> QPointF:


### PR DESCRIPTION
## Summary
- add cached non-transparent bounds to `Layer` with lazy recomputation and automatic invalidation when imagery changes
- ensure layer operations reset or copy the cached bounds as appropriate
- switch rotate and scale helpers to reuse the cached bounds instead of scanning each image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2c24feb408321bba713bcf4265eb5