### PR TITLE
Add static animation timeline panel

### DIFF
--- a/portal/ui/animation_timeline_panel.py
+++ b/portal/ui/animation_timeline_panel.py
@@ -1,0 +1,45 @@
+from PySide6.QtCore import QRectF, Qt
+from PySide6.QtGui import QPainter, QPalette, QPen
+from PySide6.QtWidgets import QSizePolicy, QWidget
+
+
+class AnimationTimelinePanel(QWidget):
+    """A simple timeline panel rendered above the status bar."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumHeight(40)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+    def paintEvent(self, event):  # noqa: N802 - Qt override naming convention
+        painter = QPainter(self)
+        rect = self.rect()
+
+        background_color = self.palette().color(QPalette.Base)
+        painter.fillRect(rect, background_color)
+
+        mid_y = rect.center().y()
+        painter.setPen(QPen(self.palette().color(QPalette.Mid)))
+        painter.drawLine(rect.left(), mid_y, rect.right(), mid_y)
+
+        tick_pen = QPen(self.palette().color(QPalette.Text))
+        painter.setPen(tick_pen)
+
+        spacing = 10
+        font_metrics = painter.fontMetrics()
+
+        for index, x in enumerate(range(rect.left(), rect.right(), spacing)):
+            is_major_tick = index % 5 == 0
+            tick_height = 13 if is_major_tick else 10
+            painter.drawLine(x, mid_y - tick_height, x, mid_y)
+
+            if is_major_tick:
+                text_rect = QRectF(
+                    x - spacing * 2,
+                    mid_y - tick_height - font_metrics.height() - 2,
+                    spacing * 4,
+                    font_metrics.height(),
+                )
+                painter.drawText(text_rect, Qt.AlignHCenter | Qt.AlignBottom, str(index))
+
+        painter.end()

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -36,6 +36,7 @@ from portal.commands.status_bar_manager import StatusBarManager
 from portal.ui.flip_dialog import FlipDialog
 from portal.ui.settings_dialog import SettingsDialog
 from portal.ui.remove_background_dialog import RemoveBackgroundDialog
+from portal.ui.animation_timeline_panel import AnimationTimelinePanel
 
 
 from PySide6.QtWidgets import QColorDialog
@@ -75,6 +76,8 @@ class MainWindow(QMainWindow):
         central_layout.setContentsMargins(0, 0, 0, 0)
         central_layout.setSpacing(0)
         central_layout.addWidget(self.canvas, 1)
+        self.animation_timeline_panel = AnimationTimelinePanel(self)
+        central_layout.addWidget(self.animation_timeline_panel)
 
         self.setCentralWidget(central_container)
         self._apply_runtime_animation_settings()


### PR DESCRIPTION
## Summary
- add a dedicated `AnimationTimelinePanel` widget that renders the frame timeline baseline, minor ticks, and numbered major ticks
- integrate the timeline panel into the main window layout directly above the status bar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d48343b4888321b3302c6add051259