### PR TITLE
Add static animation timeline panel above status bar

### DIFF
--- a/portal/ui/animation_panel.py
+++ b/portal/ui/animation_panel.py
@@ -1,0 +1,51 @@
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QFont, QPainter, QPen
+from PySide6.QtWidgets import QSizePolicy, QWidget
+
+
+class AnimationPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumHeight(64)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+    def paintEvent(self, event):  # noqa: N802 (Qt API requirement)
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, False)
+
+        rect = self.rect()
+        painter.fillRect(rect, self.palette().window())
+
+        timeline_y = rect.center().y()
+
+        line_pen = QPen(self.palette().mid().color())
+        line_pen.setWidth(1)
+        painter.setPen(line_pen)
+        painter.drawLine(rect.left(), timeline_y, rect.right(), timeline_y)
+
+        tick_pen = QPen(self.palette().mid().color())
+        painter.setPen(tick_pen)
+
+        font = QFont(self.font())
+        font.setPointSizeF(font.pointSizeF() * 0.9)
+        painter.setFont(font)
+
+        for index, x in enumerate(range(rect.left(), rect.right(), 10)):
+            if index % 5 == 0:
+                tick_height = 13
+                painter.drawLine(x, timeline_y - tick_height, x, timeline_y)
+
+                painter.drawText(
+                    x - 20,
+                    timeline_y - tick_height - 18,
+                    40,
+                    18,
+                    Qt.AlignCenter,
+                    str(index // 5),
+                )
+            else:
+                tick_height = 10
+                painter.drawLine(x, timeline_y - tick_height, x, timeline_y)
+
+        painter.end()
+

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -29,6 +29,7 @@ from portal.ui.new_file_dialog import NewFileDialog
 from portal.ui.resize_dialog import ResizeDialog
 from portal.ui.background import Background
 from portal.ui.preview_panel import PreviewPanel
+from portal.ui.animation_panel import AnimationPanel
 from portal.commands.action_manager import ActionManager
 from portal.commands.menu_bar_builder import MenuBarBuilder
 from portal.commands.tool_bar_builder import ToolBarBuilder
@@ -75,6 +76,9 @@ class MainWindow(QMainWindow):
         central_layout.setContentsMargins(0, 0, 0, 0)
         central_layout.setSpacing(0)
         central_layout.addWidget(self.canvas, 1)
+
+        self.animation_panel = AnimationPanel(self)
+        central_layout.addWidget(self.animation_panel)
 
         self.setCentralWidget(central_container)
         self._apply_runtime_animation_settings()


### PR DESCRIPTION
## Summary
- add a dedicated animation panel widget that renders a horizontal timeline with frame ticks and labels
- insert the animation panel beneath the canvas in the main window layout so it appears above the status bar

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d48343b4888321b3302c6add051259