### PR TITLE
Add animation timeline panel above status bar

### DIFF
--- a/portal/ui/animation_panel.py
+++ b/portal/ui/animation_panel.py
@@ -1,0 +1,50 @@
+from PySide6.QtCore import QSize, Qt, QRect
+from PySide6.QtGui import QPainter, QPen
+from PySide6.QtWidgets import QSizePolicy, QWidget
+
+
+class AnimationPanel(QWidget):
+    """Simple timeline visualisation shown above the status bar."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setMinimumHeight(48)
+
+    def sizeHint(self):
+        return QSize(200, 36)
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, False)
+
+        rect = self.rect()
+        painter.fillRect(rect, self.palette().window())
+
+        mid_y = rect.center().y()
+        text_color = self.palette().windowText()
+
+        timeline_pen = QPen(text_color, 1)
+        painter.setPen(timeline_pen)
+        painter.drawLine(rect.left(), mid_y, rect.right(), mid_y)
+
+        for x in range(rect.left(), rect.right() + 1, 10):
+            frame_index = (x - rect.left()) // 10
+            is_major = frame_index % 5 == 0
+            line_height = 13 if is_major else 10
+
+            half_height = line_height // 2
+            top = mid_y - half_height
+            bottom = mid_y + (line_height - half_height)
+            painter.drawLine(x, top, x, bottom)
+
+            if is_major:
+                text = str(frame_index)
+                label_bottom = top - 4
+                if label_bottom > 0:
+                    label_rect = QRect(x - 20, 0, 40, label_bottom)
+                    painter.drawText(label_rect, Qt.AlignHCenter | Qt.AlignBottom, text)
+
+        painter.end()

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -29,6 +29,7 @@ from portal.ui.new_file_dialog import NewFileDialog
 from portal.ui.resize_dialog import ResizeDialog
 from portal.ui.background import Background
 from portal.ui.preview_panel import PreviewPanel
+from portal.ui.animation_panel import AnimationPanel
 from portal.commands.action_manager import ActionManager
 from portal.commands.menu_bar_builder import MenuBarBuilder
 from portal.commands.tool_bar_builder import ToolBarBuilder
@@ -74,7 +75,9 @@ class MainWindow(QMainWindow):
         central_layout = QVBoxLayout(central_container)
         central_layout.setContentsMargins(0, 0, 0, 0)
         central_layout.setSpacing(0)
+        self.animation_panel = AnimationPanel(self)
         central_layout.addWidget(self.canvas, 1)
+        central_layout.addWidget(self.animation_panel)
 
         self.setCentralWidget(central_container)
         self._apply_runtime_animation_settings()


### PR DESCRIPTION
## Summary
- add a lightweight AnimationPanel widget that renders the timeline guide with ticks and frame numbers
- place the new panel beneath the canvas and above the status bar in the main window layout

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d48343b4888321b3302c6add051259