### PR TITLE
Add animation timeline panel above status bar

### DIFF
--- a/portal/ui/animation_panel.py
+++ b/portal/ui/animation_panel.py
@@ -1,0 +1,53 @@
+from PySide6.QtCore import QRect, Qt
+from PySide6.QtGui import QPainter, QPen, QPalette
+from PySide6.QtWidgets import QWidget, QSizePolicy
+
+
+class AnimationPanel(QWidget):
+    """Simple timeline panel showing equally spaced frame markers."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumHeight(60)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+    def paintEvent(self, event):  # noqa: N802 - Qt override
+        super().paintEvent(event)
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, False)
+
+        rect = self.rect()
+        if rect.height() <= 0 or rect.width() <= 0:
+            return
+
+        timeline_y = rect.center().y()
+
+        pen = QPen(self.palette().color(QPalette.WindowText))
+        painter.setPen(pen)
+
+        painter.drawLine(rect.left(), timeline_y, rect.right(), timeline_y)
+
+        step = 10
+        for index, x in enumerate(range(rect.left(), rect.right() + 1, step)):
+            if index % 5 == 0:
+                marker_height = 13
+            else:
+                marker_height = 10
+
+            top = timeline_y - marker_height
+            painter.drawLine(x, timeline_y, x, top)
+
+            if index % 5 == 0:
+                text = str(index)
+                metrics = painter.fontMetrics()
+                text_width = metrics.horizontalAdvance(text)
+                text_height = metrics.height()
+                text_rect = QRect(
+                    x - text_width // 2,
+                    top - text_height - 2,
+                    text_width,
+                    text_height,
+                )
+                painter.drawText(text_rect, Qt.AlignCenter, text)
+
+        painter.end()

--- a/portal/ui/ui.py
+++ b/portal/ui/ui.py
@@ -29,6 +29,7 @@ from portal.ui.new_file_dialog import NewFileDialog
 from portal.ui.resize_dialog import ResizeDialog
 from portal.ui.background import Background
 from portal.ui.preview_panel import PreviewPanel
+from portal.ui.animation_panel import AnimationPanel
 from portal.commands.action_manager import ActionManager
 from portal.commands.menu_bar_builder import MenuBarBuilder
 from portal.commands.tool_bar_builder import ToolBarBuilder
@@ -75,6 +76,9 @@ class MainWindow(QMainWindow):
         central_layout.setContentsMargins(0, 0, 0, 0)
         central_layout.setSpacing(0)
         central_layout.addWidget(self.canvas, 1)
+
+        self.animation_panel = AnimationPanel(self)
+        central_layout.addWidget(self.animation_panel)
 
         self.setCentralWidget(central_container)
         self._apply_runtime_animation_settings()


### PR DESCRIPTION
## Summary
- add a simple animation timeline panel widget that draws evenly spaced frame markers and labels
- include the panel in the main window layout directly above the status bar

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d48343b4888321b3302c6add051259