### PR TITLE
Add multi-selection support to animation timeline

### DIFF
--- a/portal/core/document_controller.py
+++ b/portal/core/document_controller.py
@@ -172,8 +172,20 @@ class DocumentController(QObject):
             document.set_playback_fps(normalized)
 
     def set_playback_loop_range(self, start: int, end: int) -> None:
-        self._playback_loop_start = start
-        self._playback_loop_end = end
+        try:
+            normalized_start = int(start)
+        except (TypeError, ValueError):
+            normalized_start = 0
+        try:
+            normalized_end = int(end)
+        except (TypeError, ValueError):
+            normalized_end = normalized_start + 1
+        if normalized_start < 0:
+            normalized_start = 0
+        if normalized_end <= normalized_start:
+            normalized_end = normalized_start + 1
+        self._playback_loop_start = normalized_start
+        self._playback_loop_end = normalized_end
 
     def ensure_auto_key_for_active_layer(self) -> bool:
         """Auto-key functionality has been removed."""

--- a/tests/test_animation_panel.py
+++ b/tests/test_animation_panel.py
@@ -1,0 +1,83 @@
+import pytest
+
+from PySide6.QtCore import QPointF, Qt
+
+from portal.ui.animation_panel import AnimationPanel
+
+
+def _frame_center(panel: AnimationPanel, frame: int) -> QPointF:
+    rect = panel.rect()
+    timeline_y = rect.bottom() - 24
+    min_timeline_y = rect.top() + 40
+    if timeline_y < min_timeline_y:
+        timeline_y = min_timeline_y
+    center_y = timeline_y - 5
+    return QPointF(panel._frame_to_x(frame), center_y)
+
+
+@pytest.fixture
+def animation_panel(qtbot):
+    panel = AnimationPanel()
+    qtbot.addWidget(panel)
+    panel.resize(400, 120)
+    panel.show()
+    qtbot.waitExposed(panel)
+    return panel
+
+
+def test_click_selects_single_key(animation_panel, qtbot):
+    panel = animation_panel
+    panel.set_keyframes([2, 4, 8])
+    qtbot.wait(0)
+
+    pos = _frame_center(panel, 4).toPoint()
+    qtbot.mouseClick(panel, Qt.LeftButton, Qt.NoModifier, pos)
+    qtbot.wait(0)
+
+    assert panel.selected_keyframes == (4,)
+
+
+def test_ctrl_click_toggles_selection(animation_panel, qtbot):
+    panel = animation_panel
+    panel.set_keyframes([1, 3, 5])
+    qtbot.wait(0)
+
+    qtbot.mouseClick(panel, Qt.LeftButton, Qt.NoModifier, _frame_center(panel, 1).toPoint())
+    qtbot.wait(0)
+    qtbot.mouseClick(
+        panel,
+        Qt.LeftButton,
+        Qt.ControlModifier,
+        _frame_center(panel, 5).toPoint(),
+    )
+    qtbot.wait(0)
+
+    assert panel.selected_keyframes == (1, 5)
+
+    qtbot.mouseClick(
+        panel,
+        Qt.LeftButton,
+        Qt.ControlModifier,
+        _frame_center(panel, 1).toPoint(),
+    )
+    qtbot.wait(0)
+
+    assert panel.selected_keyframes == (5,)
+
+
+def test_shift_click_extends_selection(animation_panel, qtbot):
+    panel = animation_panel
+    panel.set_keyframes([2, 4, 6, 8])
+    qtbot.wait(0)
+
+    qtbot.mouseClick(panel, Qt.LeftButton, Qt.NoModifier, _frame_center(panel, 4).toPoint())
+    qtbot.wait(0)
+    qtbot.mouseClick(
+        panel,
+        Qt.LeftButton,
+        Qt.ShiftModifier,
+        _frame_center(panel, 8).toPoint(),
+    )
+    qtbot.wait(0)
+
+    assert panel.selected_keyframes == (4, 6, 8)


### PR DESCRIPTION
## Summary
- allow the animation timeline to track multi-keyframe selections and emit a selection change signal
- adjust timeline rendering and interactions so ctrl/shift clicks modify the selection instead of replacing it
- clamp playback loop inputs in the document controller and add unit tests that cover timeline key selection behaviour

## Testing
- QT_QPA_PLATFORM=offscreen python -m pytest tests/test_animation_panel.py tests/test_playback_loop.py

------
https://chatgpt.com/codex/tasks/task_e_68d56bdc9ba08321b3befc492705ca4c